### PR TITLE
Dev

### DIFF
--- a/CefFlashBrowser/Assets/Language/en-US.xaml
+++ b/CefFlashBrowser/Assets/Language/en-US.xaml
@@ -116,6 +116,7 @@
     <sys:String x:Key="browser_addToDictionary">Add to dictionary</sys:String>
     <sys:String x:Key="browser_reloadNoCache">Reload ignore cache</sys:String>
     <sys:String x:Key="browser_openDevTool">Open devtools</sys:String>
+    <sys:String x:Key="browser_toggleDevTool">Open/Close devtools</sys:String>
     <sys:String x:Key="browser_viewSource">View source</sys:String>
     <sys:String x:Key="browser_zoom">Zoom</sys:String>
     <sys:String x:Key="browser_openInDefaultBrowser">Open in default browser</sys:String>

--- a/CefFlashBrowser/Assets/Language/it.xaml
+++ b/CefFlashBrowser/Assets/Language/it.xaml
@@ -116,6 +116,7 @@
     <sys:String x:Key="browser_addToDictionary">Aggiungi al dizionario</sys:String>
     <sys:String x:Key="browser_reloadNoCache">Ricarica ignorando la cache</sys:String>
     <sys:String x:Key="browser_openDevTool">Apri devtools</sys:String>
+    <sys:String x:Key="browser_toggleDevTool">Apri/Chiudi devtools</sys:String>
     <sys:String x:Key="browser_viewSource">Vedi Sorgente</sys:String>
     <sys:String x:Key="browser_zoom">Zoom</sys:String>
     <sys:String x:Key="browser_openInDefaultBrowser">Apri nel browser predefinito</sys:String>

--- a/CefFlashBrowser/Assets/Language/zh-CN.xaml
+++ b/CefFlashBrowser/Assets/Language/zh-CN.xaml
@@ -116,6 +116,7 @@
     <sys:String x:Key="browser_addToDictionary">添加到字典</sys:String>
     <sys:String x:Key="browser_reloadNoCache">刷新（忽略缓存）</sys:String>
     <sys:String x:Key="browser_openDevTool">打开开发工具</sys:String>
+    <sys:String x:Key="browser_toggleDevTool">打开/关闭开发工具</sys:String>
     <sys:String x:Key="browser_viewSource">查看网页源码</sys:String>
     <sys:String x:Key="browser_zoom">缩放</sys:String>
     <sys:String x:Key="browser_openInDefaultBrowser">在默认浏览器中打开</sys:String>

--- a/CefFlashBrowser/Assets/Language/zh-TW.xaml
+++ b/CefFlashBrowser/Assets/Language/zh-TW.xaml
@@ -116,6 +116,7 @@
     <sys:String x:Key="browser_addToDictionary">新增到字典</sys:String>
     <sys:String x:Key="browser_reloadNoCache">重新整理（忽略快取）</sys:String>
     <sys:String x:Key="browser_openDevTool">開啟開發者工具</sys:String>
+    <sys:String x:Key="browser_toggleDevTool">開啟/關閉開發者工具</sys:String>
     <sys:String x:Key="browser_viewSource">檢視網頁原始碼</sys:String>
     <sys:String x:Key="browser_zoom">縮放</sys:String>
     <sys:String x:Key="browser_openInDefaultBrowser">在預設瀏覽器開啟</sys:String>

--- a/CefFlashBrowser/Models/Data/MessageTokens.cs
+++ b/CefFlashBrowser/Models/Data/MessageTokens.cs
@@ -7,6 +7,7 @@
         public const string CLOSE_MAINWINDOW = "CLOSE_MAINWINDOW";
         public const string SAVE_SETTINGS = "SAVE_SETTINGS";
         public const string SAVE_FAVORITES = "SAVE_FAVORITES";
-        public const string DEVTOOLS_SHOWN = "DEVTOOLS_SHOWN";
+        public const string DEVTOOLS_OPENED = "DEVTOOLS_OPENED";
+        public const string DEVTOOLS_CLOSED = "DEVTOOLS_CLOSED";
     }
 }

--- a/CefFlashBrowser/Models/Settings.cs
+++ b/CefFlashBrowser/Models/Settings.cs
@@ -16,6 +16,7 @@
         public FakeFlashVersionSetting FakeFlashVersionSetting { get; set; }
         public bool HideMainWindowOnBrowsing { get; set; }
         public bool FollowSystemTheme { get; set; }
+        public bool EnableIntegratedDevTools { get; set; }
 
 
         public static Settings Default => new Settings();
@@ -38,6 +39,7 @@
             FakeFlashVersionSetting = new FakeFlashVersionSetting();
             HideMainWindowOnBrowsing = false;
             FollowSystemTheme = true;
+            EnableIntegratedDevTools = true;
         }
 
         public void SetNullPropertiesToDefault()

--- a/CefFlashBrowser/Utils/HwndHelper.cs
+++ b/CefFlashBrowser/Utils/HwndHelper.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Text;
+
+namespace CefFlashBrowser.Utils
+{
+    public static class HwndHelper
+    {
+        public static int GetWindowStyle(IntPtr hwnd)
+        {
+            return (int)Win32.GetWindowLongPtr(hwnd, Win32.GWL_STYLE);
+        }
+
+        public static int SetWindowStyle(IntPtr hwnd, int style)
+        {
+            return (int)Win32.SetWindowLongPtr(hwnd, Win32.GWL_STYLE, (IntPtr)style);
+        }
+
+        public static IntPtr GetOwnerWindow(IntPtr hwnd)
+        {
+            return Win32.GetWindowLongPtr(hwnd, Win32.GWLP_HWNDPARENT);
+        }
+
+        public static IntPtr SetOwnerWindow(IntPtr hwnd, IntPtr hOwner)
+        {
+            return Win32.SetWindowLongPtr(hwnd, Win32.GWLP_HWNDPARENT, hOwner);
+        }
+
+        public static bool IsDevToolsWindow(IntPtr hwnd)
+        {
+            var clsname = new StringBuilder(256);
+            Win32.GetClassName(hwnd, clsname, clsname.Capacity);
+
+            var wndName = new StringBuilder(256);
+            Win32.GetWindowText(hwnd, wndName, wndName.Capacity);
+
+            return clsname.ToString().Equals("CefBrowserWindow", StringComparison.OrdinalIgnoreCase)
+                && wndName.ToString().StartsWith("devtools", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Find the devtools window that has the specified owner
+        /// </summary>
+        public static IntPtr FindDevTools(IntPtr pid, IntPtr hOwner)
+        {
+            IntPtr hDevTools = IntPtr.Zero;
+
+            Win32.EnumWindows((hWnd, lParam) =>
+            {
+                Win32.GetWindowThreadProcessId(hWnd, out IntPtr pidWnd);
+
+                if (pidWnd == pid
+                    && IsDevToolsWindow(hWnd)
+                    && GetOwnerWindow(hWnd) == hOwner)
+                {
+                    hDevTools = hWnd;
+                    return false;
+                }
+                return true;
+            }, IntPtr.Zero);
+
+            return hDevTools;
+        }
+
+        /// <summary>
+        /// Find the devtools window that has no owner
+        /// </summary>
+        public static IntPtr FindDevTools(IntPtr pid)
+        {
+            return FindDevTools(pid, IntPtr.Zero);
+        }
+    }
+}

--- a/CefFlashBrowser/Utils/HwndHelper.cs
+++ b/CefFlashBrowser/Utils/HwndHelper.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿using CefSharp;
+using System;
 using System.Text;
+using System.Windows;
+using System.Windows.Interop;
 
 namespace CefFlashBrowser.Utils
 {
@@ -67,6 +70,28 @@ namespace CefFlashBrowser.Utils
         public static IntPtr FindDevTools(IntPtr pid)
         {
             return FindDevTools(pid, IntPtr.Zero);
+        }
+
+        /// <summary>
+        /// Find the top-level devtools window that owned by the specified browser
+        /// </summary>
+        public static IntPtr FindNotIntegratedDevTools(IWebBrowser browser)
+        {
+            var obj = browser as DependencyObject;
+
+            while (obj != null && !(obj is Window))
+            {
+                obj = LogicalTreeHelper.GetParent(obj);
+            }
+
+            if (obj is Window w)
+            {
+                IntPtr hwnd = new WindowInteropHelper(w).Handle;
+                Win32.GetWindowThreadProcessId(hwnd, out IntPtr pidWnd);
+                return FindDevTools(pidWnd, hwnd);
+            }
+
+            return IntPtr.Zero;
         }
     }
 }

--- a/CefFlashBrowser/Utils/Win32.cs
+++ b/CefFlashBrowser/Utils/Win32.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -6,13 +7,32 @@ namespace CefFlashBrowser.Utils
 {
     public static class Win32
     {
+        // window messages
         public const int WM_MOVE = 0x0003;
 
-        public const int GWLP_HWNDPARENT = -8;
+        // window styles
+        public const int WS_CHILD = 0x40000000;
+        public const int WS_VISIBLE = 0x10000000;
 
+        // get/set window long
+        public const int GWLP_HWNDPARENT = -8;
+        public const int GWL_STYLE = -16;
+
+        // dwm attributes
         public const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
 
+        // enum windows callback
         public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+        // rect structure
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
 
 
         [DllImport("dwmapi.dll")]
@@ -38,5 +58,25 @@ namespace CefFlashBrowser.Utils
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr CreateWindowEx(
+            uint dwExStyle, string lpClassName, string lpWindowName, uint dwStyle, int X, int Y, int nWidth, int nHeight,
+            IntPtr hWndParent, IntPtr hMenu, IntPtr hInstance, IntPtr lpParam);
+
+        [DllImport("user32.dll")]
+        public static extern bool DestroyWindow(IntPtr hWnd);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr SetParent(IntPtr hWndChild, IntPtr hWndNewParent);
+
+        [DllImport("user32.dll")]
+        public static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
+
+        [DllImport("user32.dll")]
+        public static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
     }
 }

--- a/CefFlashBrowser/Utils/WindowManager.cs
+++ b/CefFlashBrowser/Utils/WindowManager.cs
@@ -276,50 +276,5 @@ namespace CefFlashBrowser.Utils
             });
             callback?.Invoke(dialog.DialogResult, dialog.ItemName, dialog.SelectedType);
         }
-
-        public static IntPtr GetOwnerHandle(IntPtr hwnd)
-        {
-            return Win32.GetWindowLongPtr(hwnd, Win32.GWLP_HWNDPARENT);
-        }
-
-        public static void SetOwnerHandle(IntPtr hwnd, IntPtr hOwner)
-        {
-            Win32.SetWindowLongPtr(hwnd, Win32.GWLP_HWNDPARENT, hOwner);
-        }
-
-        private static bool IsDevToolsWindow(IntPtr hwnd)
-        {
-            var clsname = new StringBuilder(256);
-            Win32.GetClassName(hwnd, clsname, clsname.Capacity);
-
-            var wndName = new StringBuilder(256);
-            Win32.GetWindowText(hwnd, wndName, wndName.Capacity);
-
-            return clsname.ToString().Equals("CefBrowserWindow", StringComparison.OrdinalIgnoreCase)
-                && wndName.ToString().StartsWith("devtools", StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Find the devtools window that has no owner
-        /// </summary>
-        public static IntPtr FindDevTools(IntPtr pid)
-        {
-            IntPtr hDevTools = IntPtr.Zero;
-
-            Win32.EnumWindows((hWnd, lParam) =>
-            {
-                Win32.GetWindowThreadProcessId(hWnd, out IntPtr pidWnd);
-
-                if (pidWnd == pid && IsDevToolsWindow(hWnd)
-                    && GetOwnerHandle(hWnd) == IntPtr.Zero)
-                {
-                    hDevTools = hWnd;
-                    return false;
-                }
-                return true;
-            }, IntPtr.Zero);
-
-            return hDevTools;
-        }
     }
 }

--- a/CefFlashBrowser/ViewModels/BrowserWindowViewModel.cs
+++ b/CefFlashBrowser/ViewModels/BrowserWindowViewModel.cs
@@ -141,7 +141,8 @@ namespace CefFlashBrowser.ViewModels
         {
             if (browser != null)
             {
-                if (DevToolsHandle == IntPtr.Zero)
+                if (DevToolsHandle == IntPtr.Zero
+                    && HwndHelper.FindNotIntegratedDevTools(browser) == IntPtr.Zero)
                 {
                     browser.ShowDevTools();
                     Messenger.Global.Send(MessageTokens.DEVTOOLS_OPENED, browser);

--- a/CefFlashBrowser/ViewModels/BrowserWindowViewModel.cs
+++ b/CefFlashBrowser/ViewModels/BrowserWindowViewModel.cs
@@ -21,13 +21,20 @@ namespace CefFlashBrowser.ViewModels
         public DelegateCommand ReloadOrStopCommand { get; set; }
         public DelegateCommand OpenInSwfPlayerCommand { get; set; }
         public DelegateCommand NewBrowserWindowCommand { get; set; }
-        public DelegateCommand ShowDevToolsCommand { get; set; }
+        public DelegateCommand ToggleDevToolsCommand { get; set; }
 
         private string _address = "about:blank";
         public string Address
         {
             get => _address;
             set => UpdateValue(ref _address, value);
+        }
+
+        private IntPtr _devtoolsHandle = IntPtr.Zero;
+        public IntPtr DevToolsHandle
+        {
+            get => _devtoolsHandle;
+            set => UpdateValue(ref _devtoolsHandle, value);
         }
 
         public void ShowMainWindow()
@@ -130,12 +137,21 @@ namespace CefFlashBrowser.ViewModels
             WindowManager.ShowBrowser(url ?? "about:blank");
         }
 
-        public void ShowDevTools(IWebBrowser browser)
+        public void ToggleDevTools(IWebBrowser browser)
         {
             if (browser != null)
             {
-                browser.ShowDevTools();
-                Messenger.Global.Send(MessageTokens.DEVTOOLS_SHOWN, browser);
+                if (DevToolsHandle == IntPtr.Zero)
+                {
+                    browser.ShowDevTools();
+                    Messenger.Global.Send(MessageTokens.DEVTOOLS_OPENED, browser);
+                }
+                else
+                {
+                    DevToolsHandle = IntPtr.Zero;
+                    browser.CloseDevTools();
+                    Messenger.Global.Send(MessageTokens.DEVTOOLS_CLOSED, browser);
+                }
             }
         }
 
@@ -149,7 +165,7 @@ namespace CefFlashBrowser.ViewModels
             ReloadOrStopCommand = new DelegateCommand<IWebBrowser>(ReloadOrStop);
             OpenInSwfPlayerCommand = new DelegateCommand<string>(OpenInSwfPlayer);
             NewBrowserWindowCommand = new DelegateCommand<string>(NewBrowserWindow);
-            ShowDevToolsCommand = new DelegateCommand<IWebBrowser>(ShowDevTools);
+            ToggleDevToolsCommand = new DelegateCommand<IWebBrowser>(ToggleDevTools);
         }
     }
 }

--- a/CefFlashBrowser/Views/BrowserWindow.xaml
+++ b/CefFlashBrowser/Views/BrowserWindow.xaml
@@ -13,6 +13,7 @@
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:CefFlashBrowser.Utils.Behaviors"
         xmlns:hc="https://handyorg.github.io/handycontrol"
+        xmlns:c="clr-namespace:CefFlashBrowser.Views.Custom"
         mc:Ignorable="d"
         
         x:Name="window"
@@ -134,7 +135,8 @@
             <Separator/>
 
             <MenuItem Header="{DynamicResource browser_openDevTool}"
-                      Command="{Binding Source={x:Reference Name=browser}, Path=ShowDevToolsCommand}"
+                      Command="{Binding ToggleDevToolsCommand}"
+                      CommandParameter="{Binding Source={x:Reference Name=browser}}"
                       InputGestureText="F12"/>
             <MenuItem Header="{DynamicResource browser_viewSource}"
                       Command="{Binding ViewSourceCommand}"
@@ -194,7 +196,7 @@
         <KeyBinding Key="F11"
                     Command="{Binding ElementName=window, Path=ToggleFullScreenCommand}"/>
         <KeyBinding Key="F12"
-                    Command="{Binding ShowDevToolsCommand}"
+                    Command="{Binding ToggleDevToolsCommand}"
                     CommandParameter="{Binding ElementName=browser}"/>
         <KeyBinding Gesture="Ctrl+OemPlus"
                     Command="{Binding ElementName=browser, Path=ZoomInCommand}"/>
@@ -372,10 +374,42 @@
             </Grid>
         </DockPanel>
 
-        <flash:ChromiumFlashBrowser x:Name="browser"
-                                    Grid.Row="1"
-                                    ZoomLevelIncrement="0.25"
-                                    Address="{Binding Address, TargetNullValue='about:blank'}"/>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition x:Name="devtoolsColumn" Width="Auto"
+                                  MinWidth="{Binding ElementName=devtoolsContainer, Path=MinWidth}"
+                                  MaxWidth="{Binding RelativeSource={RelativeSource AncestorType=Grid}, Path=ActualWidth, Converter={StaticResource TwoThird}}"/>
+            </Grid.ColumnDefinitions>
+
+            <flash:ChromiumFlashBrowser x:Name="browser"
+                                        ZoomLevelIncrement="0.25"
+                                        Address="{Binding Address, TargetNullValue='about:blank'}"/>
+
+            <GridSplitter Grid.Column="1"
+                          Width="5"
+                          Background="Transparent"
+                          HorizontalAlignment="Stretch"
+                          Visibility="{Binding ElementName=devtoolsContainer, Path=Visibility}"/>
+
+            <c:HwndContainer x:Name="devtoolsContainer"
+                             Grid.Column="2"
+                             ContentHandle="{Binding DevToolsHandle}">
+                <c:HwndContainer.Style>
+                    <Style TargetType="{x:Type c:HwndContainer}">
+                        <Setter Property="MinWidth" Value="300"/>
+                        <Style.Triggers>
+                            <Trigger Property="ContentHandle"
+                                     Value="{x:Static sys:IntPtr.Zero}">
+                                <Setter Property="MinWidth" Value="0"/>
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </c:HwndContainer.Style>
+            </c:HwndContainer>
+        </Grid>
 
         <Popup x:Name="statusPopup"
                IsOpen="{Binding ElementName=window, Path=IsActive, Mode=OneWay}"

--- a/CefFlashBrowser/Views/BrowserWindow.xaml
+++ b/CefFlashBrowser/Views/BrowserWindow.xaml
@@ -134,7 +134,7 @@
 
             <Separator/>
 
-            <MenuItem Header="{DynamicResource browser_openDevTool}"
+            <MenuItem Header="{DynamicResource browser_toggleDevTool}"
                       Command="{Binding ToggleDevToolsCommand}"
                       CommandParameter="{Binding Source={x:Reference Name=browser}}"
                       InputGestureText="F12"/>

--- a/CefFlashBrowser/Views/BrowserWindow.xaml.cs
+++ b/CefFlashBrowser/Views/BrowserWindow.xaml.cs
@@ -337,7 +337,8 @@ namespace CefFlashBrowser.Views
                         // Set current window as the owner of the DevTools window
                         HwndHelper.SetOwnerWindow(hDevTools, hwnd);
 
-                        if (DataContext is BrowserWindowViewModel vm)
+                        if (DataContext is BrowserWindowViewModel vm
+                            && GlobalData.Settings.EnableIntegratedDevTools)
                         {
                             HwndHelper.SetWindowStyle(hDevTools, Win32.WS_CHILD | Win32.WS_VISIBLE);
                             vm.DevToolsHandle = hDevTools;

--- a/CefFlashBrowser/Views/BrowserWindow.xaml.cs
+++ b/CefFlashBrowser/Views/BrowserWindow.xaml.cs
@@ -2,6 +2,7 @@
 using CefFlashBrowser.Models;
 using CefFlashBrowser.Models.Data;
 using CefFlashBrowser.Utils;
+using CefFlashBrowser.ViewModels;
 using CefFlashBrowser.WinformCefSharp4WPF;
 using CefSharp;
 using SimpleMvvm.Command;
@@ -111,6 +112,7 @@ namespace CefFlashBrowser.Views
 
         private bool _doClose = false;
         private bool _isMaximizedBeforeFullScreen = false;
+        private GridLength _devToolsColumnWidth = new GridLength(0, GridUnitType.Auto);
 
         public ICommand ToggleFullScreenCommand { get; }
 
@@ -140,10 +142,16 @@ namespace CefFlashBrowser.Views
             browser.MenuHandler = new BrowserMenuHandler(this);
 
             BindingOperations.SetBinding(this, FullScreenProperty, new Binding
-            { Source = browser, Path = new PropertyPath("FullscreenMode"), Mode = BindingMode.OneWay });
+            { Source = browser, Path = new PropertyPath(nameof(browser.FullscreenMode)), Mode = BindingMode.OneWay });
 
-            Messenger.Global.Register(MessageTokens.DEVTOOLS_SHOWN, DevToolsShownHandler);
-            Closed += delegate { Messenger.Global.Unregister(MessageTokens.DEVTOOLS_SHOWN, DevToolsShownHandler); };
+            Messenger.Global.Register(MessageTokens.DEVTOOLS_OPENED, DevToolsOpenedHandler);
+            Messenger.Global.Register(MessageTokens.DEVTOOLS_CLOSED, DevToolsClosedHandler);
+
+            Closed += delegate
+            {
+                Messenger.Global.Unregister(MessageTokens.DEVTOOLS_OPENED, DevToolsOpenedHandler);
+                Messenger.Global.Unregister(MessageTokens.DEVTOOLS_CLOSED, DevToolsClosedHandler);
+            };
         }
 
         private WindowSizeInfo GetSizeInfo()
@@ -284,15 +292,23 @@ namespace CefFlashBrowser.Views
             OpenBottomContextMenu((UIElement)sender, (ContextMenu)Resources["blockedSwfs"]);
         }
 
-        private void DevToolsShownHandler(object obj)
+        private void DevToolsOpenedHandler(object obj)
         {
-            if (obj is IWebBrowser b && b == browser)
+            if (obj == browser)
             {
-                OnDevToolsShown();
+                OnDevToolsOpened();
             }
         }
 
-        private void OnDevToolsShown()
+        private void DevToolsClosedHandler(object obj)
+        {
+            if (obj == browser)
+            {
+                OnDevToolsClosed();
+            }
+        }
+
+        private void OnDevToolsOpened()
         {
             var hwnd = new WindowInteropHelper(this).Handle;
             if (hwnd == null) return;
@@ -305,25 +321,46 @@ namespace CefFlashBrowser.Views
                 IntPtr hDevTools = IntPtr.Zero;
 
                 int cnt;
-                for (cnt = 0; cnt < 5; cnt++)
+                for (cnt = 0; cnt < 8; cnt++)
                 {
-                    hDevTools = WindowManager.FindDevTools(pid);
+                    hDevTools = HwndHelper.FindDevTools(pid);
 
                     if (hDevTools == IntPtr.Zero)
                         await Task.Delay(100);
                     else break;
                 }
 
-                if (hDevTools != IntPtr.Zero)
+                Dispatcher.Invoke(() =>
                 {
-                    // Set current window as the owner of the DevTools window
-                    WindowManager.SetOwnerHandle(hDevTools, hwnd);
-                }
-                else
-                {
-                    LogHelper.LogInfo($"DevTools window not found after {cnt} attempts.");
-                }
+                    if (hDevTools != IntPtr.Zero)
+                    {
+                        // Set current window as the owner of the DevTools window
+                        HwndHelper.SetOwnerWindow(hDevTools, hwnd);
+
+                        if (DataContext is BrowserWindowViewModel vm)
+                        {
+                            HwndHelper.SetWindowStyle(hDevTools, Win32.WS_CHILD | Win32.WS_VISIBLE);
+                            vm.DevToolsHandle = hDevTools;
+
+                            Activate();
+                            Keyboard.Focus(browser);
+                            devtoolsColumn.Width = _devToolsColumnWidth;
+                        }
+                    }
+                    else
+                    {
+                        LogHelper.LogError($"DevTools window not found after {cnt} attempts.");
+                    }
+                });
             });
+        }
+
+        private void OnDevToolsClosed()
+        {
+            Activate();
+            Keyboard.Focus(browser);
+            _devToolsColumnWidth = devtoolsColumn.Width;
+            devtoolsColumn.Width = new GridLength(0, GridUnitType.Auto);
         }
     }
 }

--- a/CefFlashBrowser/Views/Custom/HwndContainer.cs
+++ b/CefFlashBrowser/Views/Custom/HwndContainer.cs
@@ -1,0 +1,75 @@
+﻿using CefFlashBrowser.Utils;
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace CefFlashBrowser.Views.Custom
+{
+    public class HwndContainer : HwndHost
+    {
+        private HandleRef _hSelf;
+
+
+        public IntPtr ContentHandle
+        {
+            get { return (IntPtr)GetValue(ContentHandleProperty); }
+            set { SetValue(ContentHandleProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for ContentHandle.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ContentHandleProperty =
+            DependencyProperty.Register("ContentHandle", typeof(IntPtr), typeof(HwndContainer), new PropertyMetadata(IntPtr.Zero, ContentHandlePropertyChangedHandler));
+
+        private static void ContentHandlePropertyChangedHandler(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is HwndContainer container
+                && e.OldValue is IntPtr hOld
+                && e.NewValue is IntPtr hNew)
+            {
+                container.OnContentHandleChanged(hOld, hNew);
+            }
+        }
+
+
+        public HwndContainer()
+        {
+        }
+
+        protected override HandleRef BuildWindowCore(HandleRef hwndParent)
+        {
+            return _hSelf = new HandleRef(this, Win32.CreateWindowEx(
+                0, "STATIC", "", Win32.WS_CHILD | Win32.WS_VISIBLE, 0, 0, 0, 0,
+                hwndParent.Handle, IntPtr.Zero, Win32.GetModuleHandle(null), IntPtr.Zero));
+        }
+
+        protected override void DestroyWindowCore(HandleRef hwnd)
+        {
+            Win32.DestroyWindow(hwnd.Handle);
+            _hSelf = new HandleRef();
+        }
+
+        protected virtual void OnContentHandleChanged(IntPtr hOld, IntPtr hNew)
+        {
+            Win32.SetParent(hOld, IntPtr.Zero);
+            Win32.SetParent(hNew, _hSelf.Handle);
+            FillContentHandle();
+        }
+
+        protected override void OnWindowPositionChanged(Rect rcBoundingBox)
+        {
+            base.OnWindowPositionChanged(rcBoundingBox);
+            FillContentHandle();
+        }
+
+        private void FillContentHandle()
+        {
+            var contentHandle = ContentHandle;
+            if (contentHandle != IntPtr.Zero)
+            {
+                Win32.GetClientRect(_hSelf.Handle, out Win32.RECT rect);
+                Win32.MoveWindow(contentHandle, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several enhancements and modifications to the CefFlashBrowser application, primarily focusing on improving the handling of developer tools (DevTools) and refining related UI and backend logic. The changes include adding a toggle functionality for DevTools, integrating new utility methods, and updating localization strings. Below are the most significant changes grouped by theme:

### Developer Tools Enhancements:
* Replaced the `ShowDevTools` command with a `ToggleDevTools` command, allowing users to open or close DevTools dynamically. This includes updates to `BrowserWindowViewModel`, `BrowserWindow.xaml`, and related bindings. [[1]](diffhunk://#diff-386a17d493abbc0793f36313ffb1204a5ba9ca345863afcfe31d72c5d527446dL133-R155) [[2]](diffhunk://#diff-386a17d493abbc0793f36313ffb1204a5ba9ca345863afcfe31d72c5d527446dL152-R169) [[3]](diffhunk://#diff-4af6dc1d0619deac28a634923f126a7999ba063d74c22824a738dd8068ff18fcL136-R139) [[4]](diffhunk://#diff-4af6dc1d0619deac28a634923f126a7999ba063d74c22824a738dd8068ff18fcL197-R199)
* Introduced a new property `DevToolsHandle` in `BrowserWindowViewModel` to track the DevTools window handle. This enables better integration and management of DevTools windows.
* Added a collapsible DevTools container in the UI, allowing users to view DevTools alongside the browser window. This includes a `GridSplitter` for adjustable width and a new `HwndContainer` for embedding the DevTools window.

### Localization Updates:
* Updated localization files (`en-US.xaml`, `it.xaml`, `zh-CN.xaml`, `zh-TW.xaml`) to include a new string resource for toggling DevTools (`browser_toggleDevTool`). [[1]](diffhunk://#diff-d91abd6279630655b3806922783f6a96acbafe8e4bce89e0d4f345f4aca328a3R119) [[2]](diffhunk://#diff-21b08a30b78ca68c668b5842e00b80492155137e4d5863b71011218382430424R119) [[3]](diffhunk://#diff-60da3d5337a8c61f5cb2cdde3eb5989b4abb4e104fa0d806f54e2b09ec915550R119) [[4]](diffhunk://#diff-ade9413ae820a534d92c65ca072f861a0c1f40ce267462e15d7077c68e85ffd8R119)

### Backend Improvements:
* Refactored DevTools-related window management logic by moving it from `WindowManager` to a new `HwndHelper` utility class. This centralizes functionality such as finding and managing DevTools windows. [[1]](diffhunk://#diff-e616c4b513b8e2411222df0ecd3e61df3142b54fa75e84d9982f2eb41ba6d2c6R1-R97) [[2]](diffhunk://#diff-688402f6443a5862f46cc2a5e537d2039685abf4b06068177733156743059ef2L279-L323)
* Added new constants and methods in `Win32` to support window style manipulation and DevTools window handling, such as `GetWindowStyle`, `SetWindowStyle`, and `FindDevTools`. [[1]](diffhunk://#diff-2b4f0d843e550e9317c030bd8621e11e238029954d372fdebd55f99fcac3a6e4R2-R36) [[2]](diffhunk://#diff-2b4f0d843e550e9317c030bd8621e11e238029954d372fdebd55f99fcac3a6e4R61-R80)

### Settings Enhancements:
* Added a new setting, `EnableIntegratedDevTools`, to allow users to enable or disable integrated DevTools functionality. This setting is initialized to `true` by default. [[1]](diffhunk://#diff-7848215704cdfb0827cb4bca5e314c842fb3cd59e07e42e5d496dca452efe399R19) [[2]](diffhunk://#diff-7848215704cdfb0827cb4bca5e314c842fb3cd59e07e42e5d496dca452efe399R42)

### Messaging Updates:
* Renamed the `DEVTOOLS_SHOWN` message token to `DEVTOOLS_OPENED` and introduced a new `DEVTOOLS_CLOSED` token to handle DevTools state changes more explicitly. [[1]](diffhunk://#diff-3d0171008d7e44b78e281969afa81facacfbee5d1cd7675755ac1b558b37ae0dL10-R11) [[2]](diffhunk://#diff-b40bc9dbd95cd88796815c8a2396c665c396669bb7b5feafb9db6b8db343a66dL143-R154)

These changes collectively improve the flexibility, usability, and maintainability of the browser's DevTools integration.