### PR TITLE
Dev

### DIFF
--- a/CefFlashBrowser.FlashBrowser/CefFlashBrowser.FlashBrowser.csproj
+++ b/CefFlashBrowser.FlashBrowser/CefFlashBrowser.FlashBrowser.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="CefSharp.Common" Version="84.4.10" />
-    <PackageReference Include="Mzying2001.SimpleMvvm" Version="1.1.4" />
+    <PackageReference Include="Mzying2001.SimpleMvvm" Version="1.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CefFlashBrowser.WinformCefSharp4WPF/CefFlashBrowser.WinformCefSharp4WPF.csproj
+++ b/CefFlashBrowser.WinformCefSharp4WPF/CefFlashBrowser.WinformCefSharp4WPF.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CefSharp.WinForms" Version="84.4.10" />
-    <PackageReference Include="Mzying2001.SimpleMvvm" Version="1.1.4" />
+    <PackageReference Include="Mzying2001.SimpleMvvm" Version="1.1.5" />
   </ItemGroup>
 
 </Project>

--- a/CefFlashBrowser.WinformCefSharp4WPF/CefSettings.cs
+++ b/CefFlashBrowser.WinformCefSharp4WPF/CefSettings.cs
@@ -2,9 +2,5 @@
 {
     public class CefSettings : CefSharp.CefSettingsBase
     {
-        public CefSettings()
-        {
-
-        }
     }
 }

--- a/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
+++ b/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
@@ -596,8 +596,11 @@ namespace CefFlashBrowser.WinformCefSharp4WPF
                 zoomLevel = ZoomLevel;
             }, invokeAsync: false);
 
-            // sync the zoom level when the frame starts loading
-            browser.SetZoomLevel(zoomLevel);
+            if (e.Frame.IsMain)
+            {
+                // sync the zoom level when the main frame starts loading
+                browser.SetZoomLevel(zoomLevel);
+            }
         }
 
         protected virtual void OnFrameLoadStart(FrameLoadStartEventArgs e)


### PR DESCRIPTION
This pull request includes minor dependency updates and a small code improvement. The most notable changes are an update to the `Mzying2001.SimpleMvvm` package version in two project files and a fix to ensure zoom level synchronization only occurs for the main frame load event.

Dependency updates:

* Updated `Mzying2001.SimpleMvvm` NuGet package from version 1.1.4 to 1.1.5 in both `CefFlashBrowser.FlashBrowser.csproj` and `CefFlashBrowser.WinformCefSharp4WPF.csproj` to ensure the latest features and bug fixes are included. [[1]](diffhunk://#diff-73920893ec3e7003be8a5a1cb07f0d7d27a3bb1a418aad0866bda91de6625029L12-R12) [[2]](diffhunk://#diff-0f3a2752d1e09872e732a0592d678d6b505d1d2a57bdb6859e3ecfa95447f598L13-R13)

Code improvements:

* Modified the frame load handler in `ChromiumWebBrowser.cs` to synchronize the zoom level only when the main frame starts loading, preventing unnecessary zoom resets on subframes.
* Removed an unnecessary empty constructor from the `CefSettings` class for cleaner code.