### PR TITLE
Refactor/solsavemanager

### DIFF
--- a/CefFlashBrowser/Models/SolFileInfo.cs
+++ b/CefFlashBrowser/Models/SolFileInfo.cs
@@ -4,7 +4,7 @@
     {
         public string FileName { get; set; }
         public string FilePath { get; set; }
-        public string WebsiteFolder { get; set; }
+        public string WebsiteFolderName { get; set; }
         public string PathInWebsiteFolder { get; set; }
     }
 }

--- a/CefFlashBrowser/Utils/RangeObservableCollection.cs
+++ b/CefFlashBrowser/Utils/RangeObservableCollection.cs
@@ -26,11 +26,14 @@ namespace CefFlashBrowser.Utils
             if (items == null)
                 throw new ArgumentNullException(nameof(items));
 
+            var list = items as IList<T> ?? new List<T>(items);
+            if (list.Count == 0) return;
+
             try
             {
                 _suppressNotification = true;
 
-                foreach (var item in items)
+                foreach (var item in list)
                 {
                     Items.Add(item);
                 }

--- a/CefFlashBrowser/Utils/RangeObservableCollection.cs
+++ b/CefFlashBrowser/Utils/RangeObservableCollection.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace CefFlashBrowser.Utils
+{
+    /// <summary>
+    /// ObservableCollection supporting AddRange method.
+    /// </summary>
+    public class RangeObservableCollection<T> : ObservableCollection<T>
+    {
+        private bool _suppressNotification = false;
+
+        public RangeObservableCollection() : base()
+        {
+        }
+
+        public RangeObservableCollection(IEnumerable<T> collection) : base(collection)
+        {
+        }
+
+        public void AddRange(IEnumerable<T> items)
+        {
+            if (items == null)
+                throw new ArgumentNullException(nameof(items));
+
+            try
+            {
+                _suppressNotification = true;
+
+                foreach (var item in items)
+                {
+                    Items.Add(item);
+                }
+
+                _suppressNotification = false;
+
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
+                OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            }
+            catch
+            {
+                _suppressNotification = false;
+                throw;
+            }
+        }
+
+        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
+            if (!_suppressNotification)
+            {
+                base.OnCollectionChanged(e);
+            }
+        }
+
+        protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+        {
+            if (!_suppressNotification)
+            {
+                base.OnPropertyChanged(e);
+            }
+        }
+    }
+}

--- a/CefFlashBrowser/ViewModels/SaveMgrWorkspaceViewModel.cs
+++ b/CefFlashBrowser/ViewModels/SaveMgrWorkspaceViewModel.cs
@@ -33,8 +33,8 @@ namespace CefFlashBrowser.ViewModels
             set => UpdateValue(ref _workspaceDir, value);
         }
 
-        private ObservableCollection<SolFileInfo> _solFiles;
-        public ObservableCollection<SolFileInfo> SolFiles
+        private RangeObservableCollection<SolFileInfo> _solFiles;
+        public RangeObservableCollection<SolFileInfo> SolFiles
         {
             get => _solFiles;
             set => UpdateValue(ref _solFiles, value);
@@ -49,7 +49,7 @@ namespace CefFlashBrowser.ViewModels
 
         private async Task ReloadSolFilesAsync(CancellationToken token)
         {
-            SolFiles = new ObservableCollection<SolFileInfo>();
+            SolFiles = new RangeObservableCollection<SolFileInfo>();
 
             await Task.Run(async () =>
             {
@@ -60,7 +60,7 @@ namespace CefFlashBrowser.ViewModels
                 {
                     if (buffer.Count > 0)
                     {
-                        InvokeOnUIThread(() => buffer.ForEach(item => SolFiles.Add(item)));
+                        InvokeOnUIThread(() => SolFiles.AddRange(buffer));
                         buffer.Clear();
                     }
                 }
@@ -75,9 +75,11 @@ namespace CefFlashBrowser.ViewModels
 
                         if (buffer.Count >= batch)
                             addToUI();
+
                         await Task.Yield();
                     }
                 }
+
                 addToUI();
             }, token);
         }

--- a/CefFlashBrowser/ViewModels/SaveMgrWorkspaceViewModel.cs
+++ b/CefFlashBrowser/ViewModels/SaveMgrWorkspaceViewModel.cs
@@ -1,0 +1,210 @@
+﻿using CefFlashBrowser.Models;
+using CefFlashBrowser.Utils;
+using SimpleMvvm;
+using SimpleMvvm.Command;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CefFlashBrowser.ViewModels
+{
+    public class SaveMgrWorkspaceViewModel : ViewModelBase
+    {
+        private CancellationTokenSource
+            _reloadCancellationTokenSource = new CancellationTokenSource();
+
+        public DelegateCommand ReloadSolFilesCommand { get; }
+        public DelegateCommand CancelReloadCommand { get; }
+        public DelegateCommand ShowInExplorerCommand { get; }
+        public DelegateCommand ExportSolCommand { get; }
+        public DelegateCommand ImportSolCommand { get; }
+        public DelegateCommand DeleteSolCommand { get; }
+        public DelegateCommand EditSolCommand { get; }
+
+
+        private string _workspaceDir;
+        public string WorkspaceDir
+        {
+            get => _workspaceDir;
+            set => UpdateValue(ref _workspaceDir, value);
+        }
+
+        private ObservableCollection<SolFileInfo> _solFiles;
+        public ObservableCollection<SolFileInfo> SolFiles
+        {
+            get => _solFiles;
+            set => UpdateValue(ref _solFiles, value);
+        }
+
+
+        private async Task ReloadSolFilesAsync()
+        {
+            var token = _reloadCancellationTokenSource.Token;
+            await ReloadSolFilesAsync(token);
+        }
+
+        private async Task ReloadSolFilesAsync(CancellationToken token)
+        {
+            SolFiles = new ObservableCollection<SolFileInfo>();
+
+            await Task.Run(async () =>
+            {
+                int batch = 50;
+                var buffer = new List<SolFileInfo>(batch);
+
+                void addToUI()
+                {
+                    if (buffer.Count > 0)
+                    {
+                        InvokeOnUIThread(() => buffer.ForEach(item => SolFiles.Add(item)));
+                        buffer.Clear();
+                    }
+                }
+
+                foreach (var solFile in EnumerateSolFiles())
+                {
+                    if (token.IsCancellationRequested)
+                        break;
+                    else
+                    {
+                        buffer.Add(solFile);
+
+                        if (buffer.Count >= batch)
+                            addToUI();
+                        await Task.Yield();
+                    }
+                }
+                addToUI();
+            }, token);
+        }
+
+        private IEnumerable<SolFileInfo> EnumerateSolFiles()
+        {
+            foreach (var websitePath in Directory.GetDirectories(WorkspaceDir))
+            {
+                foreach (var filePath in Directory
+                    .EnumerateFiles(websitePath, "*.sol", SearchOption.AllDirectories))
+                {
+                    yield return new SolFileInfo
+                    {
+                        FilePath = filePath,
+                        FileName = Path.GetFileName(filePath),
+                        WebsiteFolderName = Path.GetFileName(websitePath),
+                        PathInWebsiteFolder = filePath.Substring(websitePath.Length)
+                    };
+                }
+            }
+        }
+
+        public void CancelReload()
+        {
+            _reloadCancellationTokenSource.Cancel();
+            _reloadCancellationTokenSource = new CancellationTokenSource();
+        }
+
+        private void ShowInExplorer(SolFileInfo solFile)
+        {
+            try
+            {
+                Process.Start("explorer.exe", $"/select,{solFile.FilePath}");
+            }
+            catch (Exception e)
+            {
+                LogHelper.LogError("Failed to open explorer", e);
+                WindowManager.ShowError(e.Message);
+            }
+        }
+
+        private void ExportSol(SolFileInfo solFile)
+        {
+            try
+            {
+                var sfd = new Microsoft.Win32.SaveFileDialog
+                {
+                    FileName = solFile.FileName,
+                    Filter = $"{LanguageManager.GetString("common_solFile")}|*.sol",
+                };
+
+                if (sfd.ShowDialog() == true)
+                {
+                    File.Copy(solFile.FilePath, sfd.FileName, true);
+                    WindowManager.Alert(LanguageManager.GetString("message_exported"));
+                }
+            }
+            catch (Exception e)
+            {
+                LogHelper.LogError("Failed to export sol file", e);
+                WindowManager.ShowError(e.Message);
+            }
+        }
+
+        private void ImportSol(SolFileInfo solFile)
+        {
+            try
+            {
+                var ofd = new Microsoft.Win32.OpenFileDialog
+                {
+                    Filter = $"{LanguageManager.GetString("common_solFile")}|*.sol",
+                };
+
+                if (ofd.ShowDialog() == true)
+                {
+                    File.Copy(ofd.FileName, solFile.FilePath, true);
+                    WindowManager.Alert(LanguageManager.GetString("message_imported"));
+                }
+            }
+            catch (Exception e)
+            {
+                LogHelper.LogError("Failed to import sol file", e);
+                WindowManager.ShowError(e.Message);
+            }
+        }
+
+        private void DeleteSol(SolFileInfo solFile)
+        {
+            try
+            {
+                string msg = LanguageManager.GetFormattedString("message_deleteFile", solFile.FileName);
+
+                WindowManager.Confirm(msg, callback: result =>
+                {
+                    if (result == true)
+                    {
+                        File.Delete(solFile.FilePath);
+                        SolFiles.Remove(solFile);
+                        WindowManager.Alert(LanguageManager.GetString("message_deleted"));
+                    }
+                });
+            }
+            catch (Exception e)
+            {
+                LogHelper.LogError("Failed to delete sol file", e);
+                WindowManager.ShowError(e.Message);
+            }
+        }
+
+        private void EditSolFile(SolFileInfo solFile)
+        {
+            WindowManager.ShowSolEditorWindow(solFile.FilePath);
+        }
+
+        public SaveMgrWorkspaceViewModel(string directory)
+        {
+            WorkspaceDir = directory;
+
+            ReloadSolFilesCommand = new AsyncDelegateCommand(ReloadSolFilesAsync);
+            CancelReloadCommand = new DelegateCommand(CancelReload);
+            ShowInExplorerCommand = new DelegateCommand<SolFileInfo>(ShowInExplorer);
+            ExportSolCommand = new DelegateCommand<SolFileInfo>(ExportSol);
+            ImportSolCommand = new DelegateCommand<SolFileInfo>(ImportSol);
+            DeleteSolCommand = new DelegateCommand<SolFileInfo>(DeleteSol);
+            EditSolCommand = new DelegateCommand<SolFileInfo>(EditSolFile);
+
+            ReloadSolFilesCommand.Execute(null);
+        }
+    }
+}

--- a/CefFlashBrowser/ViewModels/SolSaveManagerViewModel.cs
+++ b/CefFlashBrowser/ViewModels/SolSaveManagerViewModel.cs
@@ -1,12 +1,8 @@
-﻿using CefFlashBrowser.Models;
-using CefFlashBrowser.Models.Data;
+﻿using CefFlashBrowser.Models.Data;
 using CefFlashBrowser.Utils;
 using SimpleMvvm;
 using SimpleMvvm.Command;
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -14,175 +10,44 @@ namespace CefFlashBrowser.ViewModels
 {
     public class SolSaveManagerViewModel : ViewModelBase
     {
-        public DelegateCommand ReloadWorkSpacesCommand { get; }
-        public DelegateCommand ShowInExplorerCommand { get; }
-        public DelegateCommand ExportSolCommand { get; }
-        public DelegateCommand ImportSolCommand { get; }
-        public DelegateCommand DeleteSolCommand { get; }
-        public DelegateCommand EditSolCommand { get; }
+        public DelegateCommand ReloadWorkspacesCommand { get; }
 
 
-        private string[] _workSpaces;
-        public string[] WorkSpaces
+        private SaveMgrWorkspaceViewModel[] _workspaces;
+        public SaveMgrWorkspaceViewModel[] Workspaces
         {
-            get => _workSpaces;
-            set => UpdateValue(ref _workSpaces, value);
+            get => _workspaces;
+            set => UpdateValue(ref _workspaces, value);
         }
 
-        private string _currentWorkSpace;
-        public string CurrentWorkSpace
+        private SaveMgrWorkspaceViewModel _currentWorkspace;
+        public SaveMgrWorkspaceViewModel CurrentWorkspace
         {
-            get => _currentWorkSpace;
-            set
-            {
-                UpdateValue(ref _currentWorkSpace, value);
-                SolFiles = GetSolFileInfos(value);
-            }
-        }
-
-        private ObservableCollection<SolFileInfo> _solFiles;
-        public ObservableCollection<SolFileInfo> SolFiles
-        {
-            get => _solFiles;
-            set => UpdateValue(ref _solFiles, value);
+            get => _currentWorkspace;
+            set => UpdateValue(ref _currentWorkspace, value);
         }
 
 
-        private void ReloadWorkSpaces()
+        private void ReloadWorkspaces()
         {
             try
             {
-                WorkSpaces = Directory.GetDirectories(GlobalData.SharedObjectsPath);
-                CurrentWorkSpace = WorkSpaces.FirstOrDefault();
+                Workspaces = Directory.GetDirectories(GlobalData.SharedObjectsPath)
+                    .Select(dir => new SaveMgrWorkspaceViewModel(dir)).ToArray();
+                CurrentWorkspace = Workspaces.FirstOrDefault();
             }
             catch (Exception e)
             {
+                Workspaces = Array.Empty<SaveMgrWorkspaceViewModel>();
+                CurrentWorkspace = null;
                 LogHelper.LogError("Failed to load workspaces", e);
-                WorkSpaces = Array.Empty<string>();
-                CurrentWorkSpace = null;
             }
-        }
-
-        private ObservableCollection<SolFileInfo> GetSolFileInfos(string workSpace)
-        {
-            var solFiles = new ObservableCollection<SolFileInfo>();
-            if (workSpace == null) return solFiles;
-
-            foreach (var website in Directory.GetDirectories(workSpace))
-                AddSolFiles(website, solFiles);
-            return solFiles;
-        }
-
-        private void AddSolFiles(string path, IList<SolFileInfo> list)
-        {
-            foreach (var file in Directory.GetFiles(path, "*.sol", SearchOption.AllDirectories))
-            {
-                list.Add(new SolFileInfo
-                {
-                    FilePath = file,
-                    FileName = Path.GetFileName(file),
-                    WebsiteFolder = Path.GetFileName(path),
-                    PathInWebsiteFolder = file.Substring(path.Length)
-                });
-            }
-        }
-
-        private void ShowInExplorer(SolFileInfo solFile)
-        {
-            try
-            {
-                Process.Start("explorer.exe", $"/select,{solFile.FilePath}");
-            }
-            catch (Exception e)
-            {
-                LogHelper.LogError("Failed to open explorer", e);
-                WindowManager.ShowError(e.Message);
-            }
-        }
-
-        private void ExportSol(SolFileInfo solFile)
-        {
-            try
-            {
-                var sfd = new Microsoft.Win32.SaveFileDialog
-                {
-                    FileName = solFile.FileName,
-                    Filter = $"{LanguageManager.GetString("common_solFile")}|*.sol",
-                };
-
-                if (sfd.ShowDialog() == true)
-                {
-                    File.Copy(solFile.FilePath, sfd.FileName, true);
-                    WindowManager.Alert(LanguageManager.GetString("message_exported"));
-                }
-            }
-            catch (Exception e)
-            {
-                LogHelper.LogError("Failed to export sol file", e);
-                WindowManager.ShowError(e.Message);
-            }
-        }
-
-        private void ImportSol(SolFileInfo solFile)
-        {
-            try
-            {
-                var ofd = new Microsoft.Win32.OpenFileDialog
-                {
-                    Filter = $"{LanguageManager.GetString("common_solFile")}|*.sol",
-                };
-
-                if (ofd.ShowDialog() == true)
-                {
-                    File.Copy(ofd.FileName, solFile.FilePath, true);
-                    WindowManager.Alert(LanguageManager.GetString("message_imported"));
-                }
-            }
-            catch (Exception e)
-            {
-                LogHelper.LogError("Failed to import sol file", e);
-                WindowManager.ShowError(e.Message);
-            }
-        }
-
-        private void DeleteSol(SolFileInfo solFile)
-        {
-            try
-            {
-                string msg = LanguageManager.GetFormattedString("message_deleteFile", solFile.FileName);
-
-                WindowManager.Confirm(msg, callback: result =>
-                {
-                    if (result == true)
-                    {
-                        File.Delete(solFile.FilePath);
-                        SolFiles.Remove(solFile);
-                        WindowManager.Alert(LanguageManager.GetString("message_deleted"));
-                    }
-                });
-            }
-            catch (Exception e)
-            {
-                LogHelper.LogError("Failed to delete sol file", e);
-                WindowManager.ShowError(e.Message);
-            }
-        }
-
-        private void EditSolFile(SolFileInfo solFile)
-        {
-            WindowManager.ShowSolEditorWindow(solFile.FilePath);
         }
 
         public SolSaveManagerViewModel()
         {
-            ReloadWorkSpacesCommand = new DelegateCommand(ReloadWorkSpaces);
-            ShowInExplorerCommand = new DelegateCommand<SolFileInfo>(ShowInExplorer);
-            ExportSolCommand = new DelegateCommand<SolFileInfo>(ExportSol);
-            ImportSolCommand = new DelegateCommand<SolFileInfo>(ImportSol);
-            DeleteSolCommand = new DelegateCommand<SolFileInfo>(DeleteSol);
-            EditSolCommand = new DelegateCommand<SolFileInfo>(EditSolFile);
-
-            ReloadWorkSpaces();
+            ReloadWorkspacesCommand = new DelegateCommand(ReloadWorkspaces);
+            ReloadWorkspaces();
         }
     }
 }

--- a/CefFlashBrowser/ViewModels/ViewModelLocator.cs
+++ b/CefFlashBrowser/ViewModels/ViewModelLocator.cs
@@ -11,7 +11,7 @@ namespace CefFlashBrowser.ViewModels
             SimpleIoc.Global.Register<SettingsWindowViewModel>();
             SimpleIoc.Global.Register<FavoritesManagerViewModel>();
             SimpleIoc.Global.Register<LanguageSelectorViewModel>();
-            SimpleIoc.Global.Register<SolSaveManagerViewModel>();
+            SimpleIoc.Global.Register<SolSaveManagerViewModel>(Lifetime.Transient);
             SimpleIoc.Global.Register<AddFavoriteDialogViewModel>(Lifetime.Transient);
         }
 

--- a/CefFlashBrowser/Views/SolSaveManager.xaml
+++ b/CefFlashBrowser/Views/SolSaveManager.xaml
@@ -30,7 +30,10 @@
     <Window.Resources>
         <DataTemplate x:Key="WorkspaceTemplate"
                       DataType="{x:Type vm:SaveMgrWorkspaceViewModel}">
-            <ListView>
+            <ListView VirtualizingStackPanel.IsVirtualizing="True"
+                      VirtualizingPanel.IsVirtualizingWhenGrouping="True"  
+                      VirtualizingPanel.VirtualizationMode="Recycling"
+                      ScrollViewer.CanContentScroll="True">
                 <ListView.Resources>
                     <CollectionViewSource x:Key="SolFilesView"
                                           Source="{Binding SolFiles}">
@@ -43,6 +46,12 @@
                 <ListView.ItemsSource>
                     <Binding Source="{StaticResource SolFilesView}"/>
                 </ListView.ItemsSource>
+
+                <ListView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel/>
+                    </ItemsPanelTemplate>
+                </ListView.ItemsPanel>
 
                 <ListView.GroupStyle>
                     <GroupStyle>

--- a/CefFlashBrowser/Views/SolSaveManager.xaml
+++ b/CefFlashBrowser/Views/SolSaveManager.xaml
@@ -20,7 +20,7 @@
         <KeyBinding Gesture="Ctrl+W"
                     Command="{Binding ElementName=windowBehavior, Path=CloseWindowCommand}"/>
         <KeyBinding Gesture="F5"
-                    Command="{Binding ReloadWorkSpacesCommand}"/>
+                    Command="{Binding ReloadWorkspacesCommand}"/>
     </Window.InputBindings>
 
     <i:Interaction.Behaviors>
@@ -28,12 +28,134 @@
     </i:Interaction.Behaviors>
 
     <Window.Resources>
-        <CollectionViewSource x:Key="SolFilesView"
-                              Source="{Binding SolFiles}">
-            <CollectionViewSource.GroupDescriptions>
-                <PropertyGroupDescription PropertyName="WebsiteFolder"/>
-            </CollectionViewSource.GroupDescriptions>
-        </CollectionViewSource>
+        <DataTemplate x:Key="WorkspaceTemplate"
+                      DataType="{x:Type vm:SaveMgrWorkspaceViewModel}">
+            <ListView>
+                <ListView.Resources>
+                    <CollectionViewSource x:Key="SolFilesView"
+                                          Source="{Binding SolFiles}">
+                        <CollectionViewSource.GroupDescriptions>
+                            <PropertyGroupDescription PropertyName="WebsiteFolderName"/>
+                        </CollectionViewSource.GroupDescriptions>
+                    </CollectionViewSource>
+                </ListView.Resources>
+
+                <ListView.ItemsSource>
+                    <Binding Source="{StaticResource SolFilesView}"/>
+                </ListView.ItemsSource>
+
+                <ListView.GroupStyle>
+                    <GroupStyle>
+                        <GroupStyle.ContainerStyle>
+                            <Style TargetType="GroupItem">
+                                <Setter Property="Margin" Value="0,0,0,5"/>
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="GroupItem">
+                                            <Expander>
+                                                <Expander.Style>
+                                                    <Style TargetType="Expander"
+                                                           BasedOn="{StaticResource {x:Type Expander}}">
+                                                        <Setter Property="IsExpanded" Value="True"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Name}"
+                                                                         Value="macromedia.com">
+                                                                <!--Collapse items of `macromedia.com` by default-->
+                                                                <Setter Property="IsExpanded" Value="False"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Expander.Style>
+                                                <Expander.Header>
+                                                    <TextBlock FontWeight="Bold"
+                                                               Text="{Binding Name}"/>
+                                                </Expander.Header>
+                                                <Expander.Content>
+                                                    <ItemsPresenter Margin="0,3,0,0"/>
+                                                </Expander.Content>
+                                            </Expander>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </GroupStyle.ContainerStyle>
+                    </GroupStyle>
+                </ListView.GroupStyle>
+
+                <ListView.View>
+                    <GridView>
+                        <GridViewColumn Width="150"
+                                        Header="{DynamicResource solSaveManager_headerFileName}"
+                                        DisplayMemberBinding="{Binding FileName}"/>
+
+                        <GridViewColumn Width="400"
+                                        Header="{DynamicResource solSaveManager_headerFileDir}">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate DataType="{x:Type m:SolFileInfo}">
+                                    <TextBlock TextTrimming="CharacterEllipsis"
+                                               ToolTip="{Binding FilePath}">
+                                        <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.ShowInExplorerCommand}"
+                                                   CommandParameter="{Binding}"
+                                                   Foreground="{Binding RelativeSource={RelativeSource AncestorType=ListViewItem}, Path=Foreground}">
+                                            <Run Text="{Binding PathInWebsiteFolder}"/>
+                                        </Hyperlink>
+                                    </TextBlock>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+
+                        <GridViewColumn Header="{DynamicResource solSaveManager_headerOperations}">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate DataType="{x:Type m:SolFileInfo}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <StackPanel.Resources>
+                                            <Style TargetType="Button"
+                                                   BasedOn="{StaticResource {x:Type Button}}">
+                                                <Setter Property="Width" Value="30"/>
+                                                <Setter Property="Height" Value="30"/>
+                                                <Setter Property="Padding" Value="0"/>
+                                            </Style>
+                                        </StackPanel.Resources>
+                                        <Button ToolTip="{DynamicResource common_export}"
+                                                Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.ExportSolCommand}"
+                                                CommandParameter="{Binding}">
+                                            <svgc:SvgIcon Width="13.5"
+                                                          Height="13.5"
+                                                          UriSource="/Assets/Svgs/export.svg"/>
+                                        </Button>
+                                        <Button Margin="5,0,0,0"
+                                                ToolTip="{DynamicResource common_import}"
+                                                Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.ImportSolCommand}"
+                                                CommandParameter="{Binding}">
+                                            <svgc:SvgIcon Width="14"
+                                                          Height="14"
+                                                          UriSource="/Assets/Svgs/import.svg"/>
+                                        </Button>
+                                        <Button Margin="5,0,0,0"
+                                                ToolTip="{DynamicResource solSaveManager_toolTipEdit}"
+                                                Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.EditSolCommand}"
+                                                CommandParameter="{Binding}">
+                                            <svgc:SvgIcon Width="13"
+                                                          Height="13"
+                                                          UriSource="/Assets/Svgs/edit.svg"/>
+                                        </Button>
+                                        <Button Margin="5,0,0,0"
+                                                ToolTip="{DynamicResource solSaveManager_toolTipDelete}"
+                                                Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.DeleteSolCommand}"
+                                                CommandParameter="{Binding}">
+                                            <svgc:SvgIcon Width="14"
+                                                          Height="14"
+                                                          UriSource="/Assets/Svgs/trash.svg"
+                                                          Fill="{DynamicResource DangerBrush}"/>
+                                        </Button>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                    </GridView>
+                </ListView.View>
+            </ListView>
+        </DataTemplate>
     </Window.Resources>
 
     <DockPanel>
@@ -49,129 +171,21 @@
             </DockPanel.Resources>
 
             <Button Margin="0,0,10,0"
-                    Command="{Binding ReloadWorkSpacesCommand}"
+                    Command="{Binding CurrentWorkspace.ReloadSolFilesCommand}"
                     ToolTip="{DynamicResource solSaveManager_toolTipReload}">
                 <svgc:SvgIcon Width="14"
                               Height="14"
                               UriSource="/Assets/Svgs/reload.svg"/>
             </Button>
 
-            <ComboBox ItemsSource="{Binding WorkSpaces}"
-                      SelectedValue="{Binding CurrentWorkSpace}"/>
+            <ComboBox ItemsSource="{Binding Workspaces}"
+                      SelectedValue="{Binding CurrentWorkspace}"
+                      DisplayMemberPath="WorkspaceDir"/>
         </DockPanel>
 
-        <ListView Margin="10,0,10,10"
-                  ItemsSource="{Binding Source={StaticResource SolFilesView}}">
-            <ListView.GroupStyle>
-                <GroupStyle>
-                    <GroupStyle.ContainerStyle>
-                        <Style TargetType="GroupItem">
-                            <Setter Property="Margin" Value="0,0,0,5"/>
-                            <Setter Property="Template">
-                                <Setter.Value>
-                                    <ControlTemplate TargetType="GroupItem">
-                                        <Expander>
-                                            <Expander.Style>
-                                                <Style TargetType="Expander"
-                                                       BasedOn="{StaticResource {x:Type Expander}}">
-                                                    <Setter Property="IsExpanded" Value="True"/>
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding Name}"
-                                                                     Value="macromedia.com">
-                                                            <!--Collapse items of `macromedia.com` by default-->
-                                                            <Setter Property="IsExpanded" Value="False"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </Expander.Style>
-                                            <Expander.Header>
-                                                <TextBlock FontWeight="Bold"
-                                                           Text="{Binding Name}"/>
-                                            </Expander.Header>
-                                            <Expander.Content>
-                                                <ItemsPresenter Margin="0,3,0,0"/>
-                                            </Expander.Content>
-                                        </Expander>
-                                    </ControlTemplate>
-                                </Setter.Value>
-                            </Setter>
-                        </Style>
-                    </GroupStyle.ContainerStyle>
-                </GroupStyle>
-            </ListView.GroupStyle>
-
-            <ListView.View>
-                <GridView>
-                    <GridViewColumn Width="150"
-                                    Header="{DynamicResource solSaveManager_headerFileName}"
-                                    DisplayMemberBinding="{Binding FileName}"/>
-
-                    <GridViewColumn Width="400"
-                                    Header="{DynamicResource solSaveManager_headerFileDir}">
-                        <GridViewColumn.CellTemplate>
-                            <DataTemplate DataType="{x:Type m:SolFileInfo}">
-                                <TextBlock TextTrimming="CharacterEllipsis"
-                                           ToolTip="{Binding FilePath}">
-                                    <Hyperlink Command="{Binding Source={StaticResource Locator}, Path=SolSaveManagerViewModel.ShowInExplorerCommand}"
-                                               CommandParameter="{Binding}"
-                                               Foreground="{Binding RelativeSource={RelativeSource AncestorType=ListViewItem}, Path=Foreground}">
-                                        <Run Text="{Binding PathInWebsiteFolder}"/>
-                                    </Hyperlink>
-                                </TextBlock>
-                            </DataTemplate>
-                        </GridViewColumn.CellTemplate>
-                    </GridViewColumn>
-
-                    <GridViewColumn Header="{DynamicResource solSaveManager_headerOperations}">
-                        <GridViewColumn.CellTemplate>
-                            <DataTemplate DataType="{x:Type m:SolFileInfo}">
-                                <StackPanel Orientation="Horizontal">
-                                    <StackPanel.Resources>
-                                        <Style TargetType="Button"
-                                               BasedOn="{StaticResource {x:Type Button}}">
-                                            <Setter Property="Width" Value="30"/>
-                                            <Setter Property="Height" Value="30"/>
-                                            <Setter Property="Padding" Value="0"/>
-                                        </Style>
-                                    </StackPanel.Resources>
-                                    <Button ToolTip="{DynamicResource common_export}"
-                                            Command="{Binding Source={StaticResource Locator}, Path=SolSaveManagerViewModel.ExportSolCommand}"
-                                            CommandParameter="{Binding}">
-                                        <svgc:SvgIcon Width="13.5"
-                                                      Height="13.5"
-                                                      UriSource="/Assets/Svgs/export.svg"/>
-                                    </Button>
-                                    <Button Margin="5,0,0,0"
-                                            ToolTip="{DynamicResource common_import}"
-                                            Command="{Binding Source={StaticResource Locator}, Path=SolSaveManagerViewModel.ImportSolCommand}"
-                                            CommandParameter="{Binding}">
-                                        <svgc:SvgIcon Width="14"
-                                                      Height="14"
-                                                      UriSource="/Assets/Svgs/import.svg"/>
-                                    </Button>
-                                    <Button Margin="5,0,0,0"
-                                            ToolTip="{DynamicResource solSaveManager_toolTipEdit}"
-                                            Command="{Binding Source={StaticResource Locator}, Path=SolSaveManagerViewModel.EditSolCommand}"
-                                            CommandParameter="{Binding}">
-                                        <svgc:SvgIcon Width="13"
-                                                      Height="13"
-                                                      UriSource="/Assets/Svgs/edit.svg"/>
-                                    </Button>
-                                    <Button Margin="5,0,0,0"
-                                            ToolTip="{DynamicResource solSaveManager_toolTipDelete}"
-                                            Command="{Binding Source={StaticResource Locator}, Path=SolSaveManagerViewModel.DeleteSolCommand}"
-                                            CommandParameter="{Binding}">
-                                        <svgc:SvgIcon Width="14"
-                                                      Height="14"
-                                                      UriSource="/Assets/Svgs/trash.svg"
-                                                      Fill="{DynamicResource DangerBrush}"/>
-                                    </Button>
-                                </StackPanel>
-                            </DataTemplate>
-                        </GridViewColumn.CellTemplate>
-                    </GridViewColumn>
-                </GridView>
-            </ListView.View>
-        </ListView>
+        <Grid Margin="10,0,10,10">
+            <ContentControl Content="{Binding CurrentWorkspace}"
+                            ContentTemplate="{StaticResource WorkspaceTemplate}"/>
+        </Grid>
     </DockPanel>
 </Window>


### PR DESCRIPTION
This pull request refactors and improves the SOL file management functionality by introducing a new `SaveMgrWorkspaceViewModel` to encapsulate per-workspace logic, simplifying `SolSaveManagerViewModel`, and updating the UI to support these changes. The main improvements include better separation of concerns, improved performance for large file lists, and more maintainable code.

**ViewModel Refactoring and Logic Separation**
- Introduced `SaveMgrWorkspaceViewModel` to handle SOL file operations (reload, import/export, delete, edit) for a single workspace, moving related logic out of `SolSaveManagerViewModel` for cleaner separation and easier maintenance. (`CefFlashBrowser/ViewModels/SaveMgrWorkspaceViewModel.cs` [CefFlashBrowser/ViewModels/SaveMgrWorkspaceViewModel.csR1-R212](diffhunk://#diff-4c9df956908c99844f3ec9712fc7c276067b77da3362cc5e3668a146f3185024R1-R212))
- Updated `SolSaveManagerViewModel` to manage an array of workspace view models instead of handling SOL files directly, significantly simplifying its responsibilities. (`CefFlashBrowser/ViewModels/SolSaveManagerViewModel.cs` [CefFlashBrowser/ViewModels/SolSaveManagerViewModel.csL1-R50](diffhunk://#diff-426c141062f1efef89a5a0f687f01728e1704f3e3ca4f04a958202b3ef50cdfbL1-R50))

**Performance and Collection Improvements**
- Added `RangeObservableCollection<T>`, an extension of `ObservableCollection<T>` that supports efficient batch additions, improving UI responsiveness when loading large numbers of files. (`CefFlashBrowser/Utils/RangeObservableCollection.cs` [CefFlashBrowser/Utils/RangeObservableCollection.csR1-R70](diffhunk://#diff-a8dac69bfc9814831de3381ffae6d6bcd403ea20824f23a1e164abea2ebdcaeeR1-R70))

**UI and Data Binding Updates**
- Refactored `SolSaveManager.xaml` to use a new `WorkspaceTemplate` for displaying each workspace and its SOL files, utilizing virtualization and grouping for better performance and structure. Command bindings now reference the correct workspace context, ensuring actions operate on the correct data. (`CefFlashBrowser/Views/SolSaveManager.xaml` [[1]](diffhunk://#diff-dee58ac707e71852e22955f42995b8c77f5cd3c43daa93420c7afd82aadca56dL23-L64) [[2]](diffhunk://#diff-dee58ac707e71852e22955f42995b8c77f5cd3c43daa93420c7afd82aadca56dL115-R106) [[3]](diffhunk://#diff-dee58ac707e71852e22955f42995b8c77f5cd3c43daa93420c7afd82aadca56dL138-R153)
- Changed the registration of `SolSaveManagerViewModel` to transient lifetime in the view model locator, aligning with the new instantiation pattern. (`CefFlashBrowser/ViewModels/ViewModelLocator.cs` [CefFlashBrowser/ViewModels/ViewModelLocator.csL14-R14](diffhunk://#diff-e00de8d4ba5203e063c7b6812a8cd5fa0e214b813d76d662305cc82123c62ef7L14-R14))

**Model Naming Consistency**
- Renamed the property `WebsiteFolder` to `WebsiteFolderName` in `SolFileInfo` for clarity and consistency with new code. (`CefFlashBrowser/Models/SolFileInfo.cs` [CefFlashBrowser/Models/SolFileInfo.csL7-R7](diffhunk://#diff-f94fa17dd67ca27cb183c5332fcf5545f52fcfe2866a4aa4476716932b6faafcL7-R7))