### PR TITLE
bugfix: index out of range error when renaming dense array items

### DIFF
--- a/CefFlashBrowser/ViewModels/SolNodeViewModel.cs
+++ b/CefFlashBrowser/ViewModels/SolNodeViewModel.cs
@@ -43,10 +43,11 @@ namespace CefFlashBrowser.ViewModels
                                 throw new ArgumentException(LanguageManager.GetFormattedString("error_objPropAreadyExists", key));
                         }
                     }
+                    var oldName = _name;
                     _name = value;
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(DisplayName));
-                    Parent?.OnChildrenNameChanged(this);
+                    Parent?.OnChildrenNameChanged(this, oldName);
                     Editor?.OnNodeChanged(SolNodeChangeType.NameChanged, this);
                 }
             }
@@ -193,20 +194,18 @@ namespace CefFlashBrowser.ViewModels
             }
         }
 
-        protected virtual void OnChildrenNameChanged(SolNodeViewModel node)
+        protected virtual void OnChildrenNameChanged(SolNodeViewModel node, object oldName)
         {
             if (Value is SolArray arr)
             {
-                string key = GetOldName(arr.AssocPortion, node.Value);
-
-                if (key != null)
+                if (oldName is string key)
                 {
                     arr.AssocPortion.Remove(key);
                     arr.AssocPortion[node.Name.ToString()] = node.Value;
                 }
                 else
                 {
-                    int index = arr.DensePortion.IndexOf(node.Value);
+                    int index = (int)oldName;
                     int offset = (int)node.Name - index;
 
                     arr.DensePortion.RemoveAt(index);
@@ -222,22 +221,10 @@ namespace CefFlashBrowser.ViewModels
             }
             else if (Value is SolObject obj)
             {
-                string key = GetOldName(obj.Properties, node.Value);
+                string key = (string)oldName;
                 obj.Properties.Remove(key);
                 obj.Properties[node.Name.ToString()] = node.Value;
             }
-        }
-
-        private string GetOldName(Dictionary<string, object> dic, object value)
-        {
-            foreach (var item in dic)
-            {
-                if (item.Value == value)
-                {
-                    return item.Key;
-                }
-            }
-            return null;
         }
 
         public Dictionary<string, object> GetAllValues()


### PR DESCRIPTION
When dense array items are value types and the array contains duplicate values, using IndexOf returns the index of the first element, causing an incorrect index to be retrieved. This commit removes the original GetOldName method, adds an oldName parameter to OnChildrenNameChanged, and passes the old value when modifying the Name property to prevent retrieving the wrong old value.