### PR TITLE
Bugfix/review fixes

### DIFF
--- a/CefFlashBrowser.FlashBrowser/Handlers/DownloadHandler.cs
+++ b/CefFlashBrowser.FlashBrowser/Handlers/DownloadHandler.cs
@@ -6,6 +6,8 @@ namespace CefFlashBrowser.FlashBrowser.Handlers
     {
         public virtual void OnBeforeDownload(IWebBrowser chromiumWebBrowser, IBrowser browser, DownloadItem downloadItem, IBeforeDownloadCallback callback)
         {
+            if (!callback.IsDisposed)
+                callback.Dispose();
         }
 
         public virtual void OnDownloadUpdated(IWebBrowser chromiumWebBrowser, IBrowser browser, DownloadItem downloadItem, IDownloadItemCallback callback)

--- a/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
+++ b/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
@@ -451,6 +451,17 @@ namespace CefFlashBrowser.WinformCefSharp4WPF
         {
             if (!browser.IsDisposed)
             {
+                browser.JavascriptMessageReceived -= OnJavascriptMessageReceived;
+                browser.ConsoleMessage -= OnConsoleMessage;
+                browser.StatusMessage -= OnStatusMessage;
+                browser.FrameLoadStart -= OnFrameLoadStart;
+                browser.FrameLoadEnd -= OnFrameLoadEnd;
+                browser.LoadError -= OnLoadError;
+                browser.LoadingStateChanged -= OnLoadingStateChanged;
+                browser.AddressChanged -= OnAddressChanged;
+                browser.TitleChanged -= OnTitleChanged;
+                browser.IsBrowserInitializedChanged -= OnIsBrowserInitializedChanged;
+
                 browser.Dispose();
             }
 


### PR DESCRIPTION
This pull request focuses on improving resource management and event handling in the browser components. The main changes ensure that event handlers are properly unsubscribed before disposing of browser objects, and callbacks are disposed of safely to prevent resource leaks.

**Resource management and event handler cleanup:**

* Unsubscribed all event handlers from the `browser` object in `ChromiumWebBrowser.cs` before disposing of it, ensuring that no dangling references remain and helping to prevent memory leaks.

**Callback disposal:**

* Disposed of the `IBeforeDownloadCallback` in `DownloadHandler.cs` if it has not already been disposed, ensuring proper cleanup of resources during the download process.