### PR TITLE
Bugfix/security and robustness

### DIFF
--- a/CefFlashBrowser.Singleton/MsgReceiver.cpp
+++ b/CefFlashBrowser.Singleton/MsgReceiver.cpp
@@ -122,12 +122,25 @@ struct CefFlashBrowser::Singleton::NativeWnd
 
     static void SendCopyData(HWND hWnd, array<Byte>^ data)
     {
-        pin_ptr<Byte> pinnedData = &data[0];
+        if (data == nullptr) {
+            return;
+        }
 
+        // &data[0] throws IndexOutOfRangeException for an empty array, so we
+        // must pin only when there is at least one element. A zero-length
+        // WM_COPYDATA with a null lpData pointer is still a valid message.
         COPYDATASTRUCT copyData{};
         copyData.cbData = data->Length;
-        copyData.lpData = pinnedData;
-        SendMessageW(hWnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&copyData));
+
+        if (data->Length > 0) {
+            pin_ptr<Byte> pinnedData = &data[0];
+            copyData.lpData = pinnedData;
+            SendMessageW(hWnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&copyData));
+        }
+        else {
+            copyData.lpData = nullptr;
+            SendMessageW(hWnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&copyData));
+        }
     }
 };
 

--- a/CefFlashBrowser.Singleton/MsgReceiver.cpp
+++ b/CefFlashBrowser.Singleton/MsgReceiver.cpp
@@ -122,25 +122,22 @@ struct CefFlashBrowser::Singleton::NativeWnd
 
     static void SendCopyData(HWND hWnd, array<Byte>^ data)
     {
-        if (data == nullptr) {
+        // Skip null / empty payloads entirely. &data[0] throws
+        // IndexOutOfRangeException for a zero-length managed array, and even
+        // if we sent cbData=0 with lpData=nullptr the receiver's OnCopyData
+        // would then call Marshal::Copy with IntPtr::Zero as the source,
+        // which throws ArgumentNullException. There is no meaningful use
+        // case for sending a zero-byte IPC payload.
+        if (data == nullptr || data->Length == 0) {
             return;
         }
 
-        // &data[0] throws IndexOutOfRangeException for an empty array, so we
-        // must pin only when there is at least one element. A zero-length
-        // WM_COPYDATA with a null lpData pointer is still a valid message.
+        pin_ptr<Byte> pinnedData = &data[0];
+
         COPYDATASTRUCT copyData{};
         copyData.cbData = data->Length;
-
-        if (data->Length > 0) {
-            pin_ptr<Byte> pinnedData = &data[0];
-            copyData.lpData = pinnedData;
-            SendMessageW(hWnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&copyData));
-        }
-        else {
-            copyData.lpData = nullptr;
-            SendMessageW(hWnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&copyData));
-        }
+        copyData.lpData = pinnedData;
+        SendMessageW(hWnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&copyData));
     }
 };
 

--- a/CefFlashBrowser.Sol/sol.cpp
+++ b/CefFlashBrowser.Sol/sol.cpp
@@ -1,5 +1,6 @@
 #include "sol.h"
 #include "utils.h"
+#include <climits>
 #include <set>
 #include <sstream>
 
@@ -873,11 +874,17 @@ sol::SolString sol::ReadAMF0ShortString(uint8_t* data, int size, int& index)
 
 sol::SolString sol::ReadAMF0LongString(uint8_t* data, int size, int& index)
 {
-    int len = (int)ReadBigEndian<uint32_t>(data, size, index);
+    uint32_t lenU = ReadBigEndian<uint32_t>(data, size, index);
 
-    if (index + len > size) {
+    // Reject lengths that do not fit in a signed int, otherwise the cast below
+    // produces a negative value that silently passes the bounds check and
+    // results in std::string(...) being constructed with an out-of-range range.
+    if (lenU > static_cast<uint32_t>(INT_MAX) ||
+        index + static_cast<int>(lenU) > size) {
         ThrowFileEndedImproperlyOnReadingType(AMF0Type::LongString);
     }
+
+    int len = static_cast<int>(lenU);
     if (len == 0) {
         return std::string();
     }

--- a/CefFlashBrowser.Sol/sol.cpp
+++ b/CefFlashBrowser.Sol/sol.cpp
@@ -917,6 +917,15 @@ sol::SolArray sol::ReadAMF0EcmaArray(uint8_t* data, int size, int& index, SolRef
 {
     uint32_t len = ReadBigEndian<uint32_t>(data, size, index);
 
+    // Each ECMA array entry consists of a 2-byte length-prefixed key plus at
+    // least a 1-byte type tag, so an entry is no smaller than 3 bytes. Reject
+    // lengths that exceed what the remaining buffer could physically contain,
+    // otherwise a malicious file with len = 0xFFFFFFFF would loop for billions
+    // of iterations or exhaust memory before any bounds check fires.
+    if (index < 0 || index > size || len > static_cast<uint32_t>((size - index) / 3)) {
+        ThrowFileEndedImproperlyOnReadingType(AMF0Type::EcmaArray);
+    }
+
     SolArray result;
     std::string key;
 
@@ -939,6 +948,15 @@ sol::SolArray sol::ReadAMF0EcmaArray(uint8_t* data, int size, int& index, SolRef
 sol::SolArray sol::ReadAMF0StrictArray(uint8_t* data, int size, int& index, SolRefTable& reftable)
 {
     uint32_t len = ReadBigEndian<uint32_t>(data, size, index);
+
+    // Each strict-array element is at least a 1-byte type tag plus (usually)
+    // some payload, so an element is no smaller than 2 bytes. Reject lengths
+    // that cannot possibly fit in the remaining buffer, otherwise a malicious
+    // file with len = 0xFFFFFFFF would reserve 4GB of memory or loop for
+    // billions of iterations before any bounds check fires.
+    if (index < 0 || index > size || len > static_cast<uint32_t>((size - index) / 2)) {
+        ThrowFileEndedImproperlyOnReadingType(AMF0Type::StrictArray);
+    }
 
     SolArray result;
     result.dense.reserve(len);

--- a/CefFlashBrowser/App.xaml.cs
+++ b/CefFlashBrowser/App.xaml.cs
@@ -3,6 +3,7 @@ using CefFlashBrowser.Singleton;
 using CefFlashBrowser.Utils;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -16,6 +17,8 @@ namespace CefFlashBrowser
     {
         private bool _started = false;
         private readonly MsgReceiver _msgReceiver;
+        private readonly object _pendingArgsLock = new object();
+        private readonly Queue<string[]> _pendingArgs = new Queue<string[]>();
 
         public App()
         {
@@ -30,15 +33,56 @@ namespace CefFlashBrowser
                 string json = System.Text.Encoding.UTF8.GetString(e.Data);
                 LogHelper.LogInfo($"Received data from another instance, data: {json}");
 
-                if (_started &&
-                    JsonConvert.DeserializeObject<string[]>(json) is string[] args)
+                if (!(JsonConvert.DeserializeObject<string[]>(json) is string[] args))
                 {
-                    ExecuteArguments(args);
+                    return;
                 }
+
+                // If OnStartup has not finished yet, queue the args and let the
+                // startup path drain them once the main UI is up. Previously
+                // these args were silently dropped, so a second instance that
+                // sent "open this SWF" while the first instance was still
+                // initialising did nothing.
+                if (!_started)
+                {
+                    lock (_pendingArgsLock)
+                    {
+                        if (!_started)
+                        {
+                            _pendingArgs.Enqueue(args);
+                            return;
+                        }
+                    }
+                }
+
+                ExecuteArguments(args);
             }
             catch (Exception ex)
             {
                 LogHelper.LogError("Failed to process received data", ex);
+            }
+        }
+
+        private void DrainPendingArgs()
+        {
+            string[][] toExecute;
+            lock (_pendingArgsLock)
+            {
+                _started = true;
+                toExecute = _pendingArgs.ToArray();
+                _pendingArgs.Clear();
+            }
+
+            foreach (var args in toExecute)
+            {
+                try
+                {
+                    ExecuteArguments(args);
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.LogError("Failed to process queued startup args", ex);
+                }
             }
         }
 
@@ -76,7 +120,7 @@ namespace CefFlashBrowser
             }
 
             ShutdownMode = ShutdownMode.OnLastWindowClose;
-            _started = true;
+            DrainPendingArgs();
         }
 
         private void ExecuteArguments(string[] args)

--- a/CefFlashBrowser/Data/GlobalData.cs
+++ b/CefFlashBrowser/Data/GlobalData.cs
@@ -134,15 +134,39 @@ namespace CefFlashBrowser.Data
 
         public static void InitFavorites()
         {
+            Favorites = new ObservableCollection<Website>();
+
+            if (!File.Exists(FavoritesPath))
+            {
+                LogHelper.LogInfo("Favorites file does not exist, starting with empty favorites");
+                return;
+            }
+
             try
             {
                 var file = JsonConvert.DeserializeObject<FavoritesFile>(File.ReadAllText(FavoritesPath));
-                Favorites = new ObservableCollection<Website>(file.Favorites);
+
+                // Guard against both a null root (the file literally contains
+                // "null") and a null Favorites array (e.g. {"Favorites": null}
+                // or a file missing the field). Previously the code did
+                //     new ObservableCollection<Website>(file.Favorites)
+                // which threw NullReferenceException / ArgumentNullException
+                // that was silently swallowed by the outer catch, resetting
+                // the user's favorites to empty with a misleading log line.
+                if (file?.Favorites != null)
+                {
+                    Favorites = new ObservableCollection<Website>(file.Favorites);
+                }
+                else
+                {
+                    LogHelper.LogError(
+                        $"Favorites file is malformed (no Favorites array): {FavoritesPath}");
+                }
             }
             catch (Exception e)
             {
-                Favorites = new ObservableCollection<Website>();
-                LogHelper.LogError("Favorites file not found or invalid, using empty favorites", e);
+                LogHelper.LogError(
+                    $"Failed to load favorites file, starting with empty favorites: {FavoritesPath}", e);
             }
         }
 

--- a/CefFlashBrowser/ViewModels/BrowserWindowViewModel.cs
+++ b/CefFlashBrowser/ViewModels/BrowserWindowViewModel.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace CefFlashBrowser.ViewModels
 {
@@ -127,7 +128,16 @@ namespace CefFlashBrowser.ViewModels
                     if (frame == null)
                         return string.Empty;
 
-                    var result = frame.EvaluateScriptAsync("document.title", timeout: TimeSpan.FromSeconds(1)).Result;
+                    // Run the awaited call on a thread-pool thread so that the
+                    // blocking wait below cannot deadlock if EvaluateScriptAsync's
+                    // continuation ever needs to capture the caller's
+                    // SynchronizationContext. This method is invoked from the UI
+                    // thread (CreateShortcut / AddFavorite), so a naked .Result
+                    // here would in the worst case freeze the UI until the 1-second
+                    // timeout elapses.
+                    var result = Task.Run(() =>
+                        frame.EvaluateScriptAsync("document.title", timeout: TimeSpan.FromSeconds(1))
+                    ).GetAwaiter().GetResult();
                     return result?.Result?.ToString() ?? string.Empty;
                 }
             }


### PR DESCRIPTION
This pull request includes several important fixes and improvements to error handling, robustness, and startup argument processing across the codebase. The most notable changes address edge cases that could previously cause crashes, silent failures, or security issues, especially when handling malformed or malicious input files, inter-process communication, and application startup arguments.

**Startup and argument handling improvements:**

* Arguments received from a second instance during application startup are now queued and executed after initialization, ensuring no arguments are lost if received early. Previously, these arguments were silently dropped. (`CefFlashBrowser/App.xaml.cs`) [[1]](diffhunk://#diff-fb65b3011fa6a076ad70e44e9950b849464badb2014fd5ef700d561a3313d4aaR20-R21) [[2]](diffhunk://#diff-fb65b3011fa6a076ad70e44e9950b849464badb2014fd5ef700d561a3313d4aaL33-R88) [[3]](diffhunk://#diff-fb65b3011fa6a076ad70e44e9950b849464badb2014fd5ef700d561a3313d4aaL79-R123)

**Robustness and error handling for file and data parsing:**

* Added strict validation and error logging for loading the favorites file, preventing silent resets and crashes if the file is malformed or missing the `Favorites` array. (`CefFlashBrowser/Data/GlobalData.cs`)
* Improved bounds checking and input validation when parsing AMF0 strings and arrays to prevent crashes, hangs, or excessive memory usage with malformed or malicious files. (`CefFlashBrowser.Sol/sol.cpp`) [[1]](diffhunk://#diff-77750b842ed490bad0a42ddcdb32270d0e089cf3bf99b84e03cf33b810d54026L876-R887) [[2]](diffhunk://#diff-77750b842ed490bad0a42ddcdb32270d0e089cf3bf99b84e03cf33b810d54026R920-R928) [[3]](diffhunk://#diff-77750b842ed490bad0a42ddcdb32270d0e089cf3bf99b84e03cf33b810d54026R952-R960)

**Inter-process communication safety:**

* The `SendCopyData` method now skips sending null or empty payloads, preventing exceptions and meaningless IPC messages. (`CefFlashBrowser.Singleton/MsgReceiver.cpp`)

**UI thread safety:**

* Prevented potential UI deadlocks by offloading blocking script evaluation to a thread pool thread in `GetWebBrowserTitle`. (`CefFlashBrowser/ViewModels/BrowserWindowViewModel.cs`)

**Minor improvements:**

* Added necessary includes for portability and clarity. (`CefFlashBrowser.Sol/sol.cpp`, `CefFlashBrowser/ViewModels/BrowserWindowViewModel.cs`) [[1]](diffhunk://#diff-77750b842ed490bad0a42ddcdb32270d0e089cf3bf99b84e03cf33b810d54026R3) [[2]](diffhunk://#diff-386a17d493abbc0793f36313ffb1204a5ba9ca345863afcfe31d72c5d527446dR14) [[3]](diffhunk://#diff-fb65b3011fa6a076ad70e44e9950b849464badb2014fd5ef700d561a3313d4aaR6)

These changes collectively make the application more robust against unexpected or malicious input and improve reliability during startup and inter-process communication.