### PR TITLE
Bugfix/flashbrowser review fixes

### DIFF
--- a/CefFlashBrowser.FlashBrowser/ChromiumFlashBrowser.cs
+++ b/CefFlashBrowser.FlashBrowser/ChromiumFlashBrowser.cs
@@ -1,6 +1,7 @@
 ﻿using CefSharp;
 using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Windows;
 
 namespace CefFlashBrowser.FlashBrowser
@@ -82,14 +83,32 @@ namespace CefFlashBrowser.FlashBrowser
         {
             base.OnIsBrowserInitializedChanged(e);
 
-            if (IsBrowserInitialized)
+            if (!IsBrowserInitialized)
             {
-                Cef.UIThreadTaskFactory.StartNew(() =>
-                { // enable flash contents automatically
-                    var requestContext = GetBrowser().GetHost().RequestContext;
-                    requestContext.SetPreference("profile.default_content_setting_values.plugins", 1, out _);
-                });
+                return;
             }
+
+            Cef.UIThreadTaskFactory.StartNew(() =>
+            { // enable flash contents automatically
+                var browser = GetBrowser();
+                if (browser == null || browser.IsDisposed)
+                {
+                    return;
+                }
+
+                var host = browser.GetHost();
+                if (host == null)
+                {
+                    return;
+                }
+
+                var ok = host.RequestContext.SetPreference(
+                    "profile.default_content_setting_values.plugins", 1, out var error);
+                if (!ok && !string.IsNullOrEmpty(error))
+                {
+                    Debug.WriteLine($"[ChromiumFlashBrowser] Failed to enable plugins preference: {error}");
+                }
+            });
         }
     }
 }

--- a/CefFlashBrowser.FlashBrowser/ChromiumFlashBrowser.cs
+++ b/CefFlashBrowser.FlashBrowser/ChromiumFlashBrowser.cs
@@ -57,15 +57,25 @@ namespace CefFlashBrowser.FlashBrowser
             }
 
             var msg = e.Message;
-            if (msg.StartsWith("Cross-origin plugin content from"))
+            if (msg == null || !msg.StartsWith("Cross-origin plugin content from", StringComparison.Ordinal))
             {
-                var url = msg.Split(' ')?[4];
-                if (!string.IsNullOrWhiteSpace(url) && !BlockedSwfs.Contains(url))
-                {
-                    BlockedSwfs.Add(url);
-                    SetCurrentValue(HasBlockedSwfsProperty, true);
-                }
+                return;
             }
+
+            var parts = msg.Split(' ');
+            if (parts.Length <= 4)
+            {
+                return;
+            }
+
+            var url = parts[4];
+            if (string.IsNullOrWhiteSpace(url) || BlockedSwfs.Contains(url))
+            {
+                return;
+            }
+
+            BlockedSwfs.Add(url);
+            SetCurrentValue(HasBlockedSwfsProperty, true);
         }
 
         protected override void OnIsBrowserInitializedChanged(EventArgs e)

--- a/CefFlashBrowser.FlashBrowser/Handlers/RequestHandler.cs
+++ b/CefFlashBrowser.FlashBrowser/Handlers/RequestHandler.cs
@@ -7,7 +7,7 @@ namespace CefFlashBrowser.FlashBrowser.Handlers
     {
         public virtual bool GetAuthCredentials(IWebBrowser chromiumWebBrowser, IBrowser browser, string originUrl, bool isProxy, string host, int port, string realm, string scheme, IAuthCallback callback)
         {
-            return true;
+            return false;
         }
 
         public virtual IResourceRequestHandler GetResourceRequestHandler(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, bool isNavigation, bool isDownload, string requestInitiator, ref bool disableDefaultHandling)

--- a/CefFlashBrowser.FlashBrowser/Internals/WpfKeyboardHandler.cs
+++ b/CefFlashBrowser.FlashBrowser/Internals/WpfKeyboardHandler.cs
@@ -26,6 +26,10 @@ namespace CefFlashBrowser.FlashBrowser.Internals
                 element.Dispatcher.Invoke(() =>
                 {
                     PresentationSource source = PresentationSource.FromVisual(element);
+                    if (source == null)
+                    {
+                        return;
+                    }
 
                     Key key = KeyInterop.KeyFromVirtualKey(windowsKeyCode);
                     KeyEventArgs args = new KeyEventArgs(Keyboard.PrimaryDevice, source, 0, key) { RoutedEvent = Keyboard.KeyDownEvent, };


### PR DESCRIPTION
This pull request focuses on improving robustness and error handling in the Flash browser's codebase, particularly around plugin handling, browser initialization, keyboard event processing, and authentication. The changes ensure safer operations by adding more defensive programming and clearer diagnostics.

**Robustness and error handling improvements:**

* Added additional null checks and early returns in `OnConsoleMessage` and `OnIsBrowserInitializedChanged` to prevent null reference exceptions and handle unexpected states more gracefully (`ChromiumFlashBrowser.cs`).
* Added debug logging when enabling plugins fails, providing clearer diagnostics for preference-setting errors (`ChromiumFlashBrowser.cs`).
* Added a null check for `PresentationSource` in keyboard event handling to avoid exceptions when the source is unavailable (`WpfKeyboardHandler.cs`).

**Behavioral changes:**

* Changed the default return value for `GetAuthCredentials` in `RequestHandler` from `true` to `false`, which means authentication requests will now be declined by default (`RequestHandler.cs`).

**Other improvements:**

* Added a missing `using System.Diagnostics;` directive to support new debug logging (`ChromiumFlashBrowser.cs`).