### PR TITLE
Bugfix/winform wpf review fixes

### DIFF
--- a/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
+++ b/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
@@ -563,10 +563,18 @@ namespace CefFlashBrowser.WinformCefSharp4WPF
 
         protected virtual void OnAddressChanged(DependencyPropertyChangedEventArgs e)
         {
-            if (!onNotifyAddressChanged)
+            if (onNotifyAddressChanged)
             {
-                browser.Load((string)e.NewValue);
+                return;
             }
+
+            var url = (string)e.NewValue;
+            if (string.IsNullOrEmpty(url))
+            {
+                return;
+            }
+
+            browser.Load(url);
         }
 
         private void OnJavascriptMessageReceived(object sender, JavascriptMessageReceivedEventArgs e)

--- a/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
+++ b/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
@@ -669,8 +669,14 @@ namespace CefFlashBrowser.WinformCefSharp4WPF
             lock (onNotifyAddressChangedLock)
             {
                 onNotifyAddressChanged = true;
-                SetCurrentValue(AddressProperty, e.Address);
-                onNotifyAddressChanged = false;
+                try
+                {
+                    SetCurrentValue(AddressProperty, e.Address);
+                }
+                finally
+                {
+                    onNotifyAddressChanged = false;
+                }
             }
             AddressChanged?.Invoke(this, e);
         }

--- a/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
+++ b/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
@@ -571,7 +571,7 @@ namespace CefFlashBrowser.WinformCefSharp4WPF
             var url = (string)e.NewValue;
             if (string.IsNullOrEmpty(url))
             {
-                return;
+                url = "about:blank";
             }
 
             browser.Load(url);

--- a/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
+++ b/CefFlashBrowser.WinformCefSharp4WPF/ChromiumWebBrowser.cs
@@ -569,9 +569,10 @@ namespace CefFlashBrowser.WinformCefSharp4WPF
             }
 
             var url = (string)e.NewValue;
+
             if (string.IsNullOrEmpty(url))
             {
-                url = "about:blank";
+                url = e.OldValue as string ?? "about:blank";
             }
 
             browser.Load(url);


### PR DESCRIPTION
This pull request improves the handling of address changes in the `ChromiumWebBrowser` component by refining the logic for updating and loading URLs, and by making the notification flag management more robust. The changes help prevent unintended browser reloads and ensure that the notification state is correctly managed even if exceptions occur.

**Address change handling improvements:**

* Updated the `OnAddressChanged(DependencyPropertyChangedEventArgs e)` method to only reload the browser when necessary, and to default to the previous URL or `"about:blank"` if the new value is null or empty. This prevents unnecessary reloads and handles edge cases more gracefully.

**Notification flag management:**

* Modified the `OnAddressChanged(AddressChangedEventArgs e)` method to use a `try/finally` block when setting the `onNotifyAddressChanged` flag. This ensures the flag is always reset, even if an exception occurs, preventing inconsistent state.