### PR TITLE
Dev

### DIFF
--- a/CefFlashBrowser/Utils/DialogHelper.cs
+++ b/CefFlashBrowser/Utils/DialogHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
@@ -104,12 +105,14 @@ namespace CefFlashBrowser.Utils
             var hOwner = new WindowInteropHelper(owner).Handle;
             bool storeEnabled = Win32.IsWindowEnabled(hOwner);
 
-            // Re-enable the owner BEFORE the HWND is destroyed (in Closing),
-            // so Windows activates the owner (not another window) on close.
-            window.Closing += (s, e) =>
+            // Re-enable the owner from GetPreCloseHandlers BEFORE WM_DESTROY
+            // tears down the HWND, so Windows activates the owner (not another window) on close.
+            window.SourceInitialized += (s, e) =>
             {
-                if (!e.Cancel)
+                GetPreCloseHandlers(window).Add(delegate
+                {
                     Win32.EnableWindow(hOwner, storeEnabled);
+                });
             };
 
             window.Closed += (s, e) =>
@@ -123,6 +126,55 @@ namespace CefFlashBrowser.Utils
             Win32.EnableWindow(hOwner, false);
             Dispatcher.PushFrame(frame);
             return GetDialogResult(window);
+        }
+
+        /// <summary>
+        /// Gets the handlers that run just before the window HWND is destroyed.
+        /// </summary>
+        /// <remarks>
+        /// The hook is attached through the window's HwndSource, so the window must
+        /// already be initialized before calling this method.
+        /// </remarks>
+        /// <param name="window">The window to attach the pre-close hook to.</param>
+        /// <returns>The list of handlers invoked from WM_DESTROY.</returns>
+        public static List<EventHandler> GetPreCloseHandlers(Window window)
+        {
+            if (window == null)
+                throw new ArgumentNullException(nameof(window));
+
+            const string key = "__PreCloseHandlers";
+
+            List<EventHandler> getHandlers(Window wnd)
+            {
+                return wnd.Resources.Contains(key) ? wnd.Resources[key] as List<EventHandler> : null;
+            }
+
+            if (getHandlers(window) is List<EventHandler> handlers)
+            {
+                return handlers;
+            }
+            else
+            {
+                handlers = new List<EventHandler>();
+
+                IntPtr wndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+                {
+                    if (msg == Win32.WM_DESTROY
+                        && getHandlers(window) is List<EventHandler> list)
+                    {
+                        foreach (var h in list.ToArray())
+                            h?.Invoke(window, EventArgs.Empty);
+                    }
+                    return IntPtr.Zero;
+                }
+
+                var source = (HwndSource)PresentationSource.FromVisual(window)
+                    ?? throw new InvalidOperationException("Window must be initialized before calling GetPreCloseHandlers.");
+
+                window.Resources[key] = handlers;
+                source.AddHook(wndProc);
+                return handlers;
+            }
         }
     }
 }

--- a/CefFlashBrowser/Utils/DialogHelper.cs
+++ b/CefFlashBrowser/Utils/DialogHelper.cs
@@ -105,15 +105,24 @@ namespace CefFlashBrowser.Utils
             var hOwner = new WindowInteropHelper(owner).Handle;
             bool storeEnabled = Win32.IsWindowEnabled(hOwner);
 
-            // Re-enable the owner from GetBeforeDestroyHandlers BEFORE WM_DESTROY
-            // tears down the HWND, so Windows activates the owner (not another window) on close.
-            window.SourceInitialized += (s, e) =>
+            // Re-enable the owner BEFORE WM_DESTROY tears down the HWND, 
+            // so Windows activates the owner (not another window) on close.
+            void beforeDestroyHandler(object s, EventArgs e)
             {
-                GetBeforeDestroyHandlers(window).Add(delegate
+                Win32.EnableWindow(hOwner, storeEnabled);
+            }
+
+            if (new WindowInteropHelper(window).Handle != IntPtr.Zero)
+            {
+                GetBeforeDestroyHandlers(window).Add(beforeDestroyHandler);
+            }
+            else
+            {
+                window.SourceInitialized += (s, e) =>
                 {
-                    Win32.EnableWindow(hOwner, storeEnabled);
-                });
-            };
+                    GetBeforeDestroyHandlers(window).Add(beforeDestroyHandler);
+                };
+            }
 
             window.Closed += (s, e) =>
             {

--- a/CefFlashBrowser/Utils/DialogHelper.cs
+++ b/CefFlashBrowser/Utils/DialogHelper.cs
@@ -124,7 +124,17 @@ namespace CefFlashBrowser.Utils
             window.Owner = owner;
             window.Show();
             Win32.EnableWindow(hOwner, false);
-            Dispatcher.PushFrame(frame);
+
+            try
+            {
+                Dispatcher.PushFrame(frame);
+            }
+            finally
+            {
+                frame.Continue = false;
+                Win32.EnableWindow(hOwner, storeEnabled);
+            }
+
             return GetDialogResult(window);
         }
 

--- a/CefFlashBrowser/Utils/DialogHelper.cs
+++ b/CefFlashBrowser/Utils/DialogHelper.cs
@@ -105,11 +105,11 @@ namespace CefFlashBrowser.Utils
             var hOwner = new WindowInteropHelper(owner).Handle;
             bool storeEnabled = Win32.IsWindowEnabled(hOwner);
 
-            // Re-enable the owner from GetPreCloseHandlers BEFORE WM_DESTROY
+            // Re-enable the owner from GetBeforeDestroyHandlers BEFORE WM_DESTROY
             // tears down the HWND, so Windows activates the owner (not another window) on close.
             window.SourceInitialized += (s, e) =>
             {
-                GetPreCloseHandlers(window).Add(delegate
+                GetBeforeDestroyHandlers(window).Add(delegate
                 {
                     Win32.EnableWindow(hOwner, storeEnabled);
                 });
@@ -145,14 +145,14 @@ namespace CefFlashBrowser.Utils
         /// The hook is attached through the window's HwndSource, so the window must
         /// already be initialized before calling this method.
         /// </remarks>
-        /// <param name="window">The window to attach the pre-close hook to.</param>
+        /// <param name="window">The window to attach the before-destroy hook to.</param>
         /// <returns>The list of handlers invoked from WM_DESTROY.</returns>
-        public static List<EventHandler> GetPreCloseHandlers(Window window)
+        public static List<EventHandler> GetBeforeDestroyHandlers(Window window)
         {
             if (window == null)
                 throw new ArgumentNullException(nameof(window));
 
-            const string key = "__PreCloseHandlers";
+            const string key = "__BeforeDestroyHandlers";
 
             List<EventHandler> getHandlers(Window wnd)
             {
@@ -179,7 +179,7 @@ namespace CefFlashBrowser.Utils
                 }
 
                 var source = (HwndSource)PresentationSource.FromVisual(window)
-                    ?? throw new InvalidOperationException("Window must be initialized before calling GetPreCloseHandlers.");
+                    ?? throw new InvalidOperationException("Window must be initialized before calling GetBeforeDestroyHandlers.");
 
                 window.Resources[key] = handlers;
                 source.AddHook(wndProc);

--- a/CefFlashBrowser/Utils/Win32.cs
+++ b/CefFlashBrowser/Utils/Win32.cs
@@ -7,6 +7,7 @@ namespace CefFlashBrowser.Utils
     public static class Win32
     {
         // window messages
+        public const int WM_DESTROY = 0x0002;
         public const int WM_MOVE = 0x0003;
 
         // window styles

--- a/CefFlashBrowser/Utils/WindowManager.cs
+++ b/CefFlashBrowser/Utils/WindowManager.cs
@@ -158,19 +158,15 @@ namespace CefFlashBrowser.Utils
                 _browserWindows.Add(window);
                 ((BrowserWindowViewModel)window.DataContext).Address = address;
 
-                window.Closing += (s, e) =>
+                DialogHelper.GetPreCloseHandlers(window).Add((s, e) =>
                 {
-                    if (e.Cancel) return;
-
                     _browserWindows.Remove((BrowserWindow)s);
 
                     if (_browserWindows.Count == 0
                         && !GlobalData.IsStartWithoutMainWindow
                         && GlobalData.Settings.HideMainWindowOnBrowsing)
-                    {
-                        ShowMainWindow();
-                    }
-                };
+                    { ShowMainWindow(); }
+                });
             });
         }
 

--- a/CefFlashBrowser/Utils/WindowManager.cs
+++ b/CefFlashBrowser/Utils/WindowManager.cs
@@ -145,6 +145,21 @@ namespace CefFlashBrowser.Utils
             });
         }
 
+        /// <summary>
+        /// If active browser window exists, return it; otherwise, return the last opened browser window.
+        /// </summary>
+        public static BrowserWindow GetCurrentBrowserWindow()
+        {
+            if (_browserWindows.FirstOrDefault(x => x.IsActive) is BrowserWindow activeWindow)
+            {
+                return activeWindow;
+            }
+            else
+            {
+                return _browserWindows.LastOrDefault();
+            }
+        }
+
 
         public static void ShowMainWindow()
         {
@@ -168,11 +183,6 @@ namespace CefFlashBrowser.Utils
                     { ShowMainWindow(); }
                 });
             });
-        }
-
-        public static BrowserWindow GetLatestBrowserWindow()
-        {
-            return _browserWindows.LastOrDefault();
         }
 
         public static void ShowSwfPlayer(string fileName)

--- a/CefFlashBrowser/Utils/WindowManager.cs
+++ b/CefFlashBrowser/Utils/WindowManager.cs
@@ -158,7 +158,7 @@ namespace CefFlashBrowser.Utils
                 _browserWindows.Add(window);
                 ((BrowserWindowViewModel)window.DataContext).Address = address;
 
-                DialogHelper.GetPreCloseHandlers(window).Add((s, e) =>
+                DialogHelper.GetBeforeDestroyHandlers(window).Add((s, e) =>
                 {
                     _browserWindows.Remove((BrowserWindow)s);
 

--- a/CefFlashBrowser/Utils/WindowManager.cs
+++ b/CefFlashBrowser/Utils/WindowManager.cs
@@ -66,7 +66,7 @@ namespace CefFlashBrowser.Utils
                 else
                 {
                     window = NewWindow<TWindow>();
-                    window.Closing += (s, e) => _singletonWindows.Remove(s.GetType());
+                    window.Closed += (s, e) => _singletonWindows.Remove(typeof(TWindow));
                     _singletonWindows.Add(typeof(TWindow), window);
                 }
             }

--- a/CefFlashBrowser/Views/BrowserWindow.xaml.cs
+++ b/CefFlashBrowser/Views/BrowserWindow.xaml.cs
@@ -200,7 +200,7 @@ namespace CefFlashBrowser.Views
         {
             WindowSizeInfo info = null;
 
-            if (WindowManager.GetLatestBrowserWindow() is Window w)
+            if (WindowManager.GetCurrentBrowserWindow() is Window w)
             {
                 info = WindowSizeInfo.GetSizeInfo(w);
                 info.Left += 20;


### PR DESCRIPTION
This pull request makes several improvements to window and dialog management in the application, focusing on more robust cleanup and activation logic. The most significant changes include introducing a "before destroy" handler mechanism for windows, updating how singleton and browser windows are tracked and closed, and providing a new way to retrieve the current browser window. These changes improve the reliability of window state handling and ensure that resources are properly cleaned up.

**Dialog and window lifecycle management:**

* Added a `GetBeforeDestroyHandlers` method to `DialogHelper.cs` that allows attaching handlers to run just before a window's HWND is destroyed (on `WM_DESTROY`). This ensures cleanup logic runs at the correct time in the window's lifecycle.
* Updated dialog code to use the new "before destroy" handler instead of the previous `Closing` event, ensuring the owner window is re-enabled at the right moment.
* Added the `WM_DESTROY` constant to `Win32.cs` for use with the new handler mechanism.

**Singleton and browser window tracking:**

* Changed singleton window removal to use the `Closed` event and fixed the type key used in the singleton windows dictionary in `WindowManager.cs`, ensuring proper cleanup when windows are closed.
* Updated browser window removal to use the new "before destroy" handler, ensuring browser windows are removed from the tracking list at the correct time and that the main window is shown when appropriate. Removed the old `GetLatestBrowserWindow` method.

**Window retrieval improvements:**

* Added a new `GetCurrentBrowserWindow` method that returns the active browser window if available, or the last opened one otherwise. Updated code to use this method for retrieving window size info. [[1]](diffhunk://#diff-688402f6443a5862f46cc2a5e537d2039685abf4b06068177733156743059ef2R148-R162) [[2]](diffhunk://#diff-b40bc9dbd95cd88796815c8a2396c665c396669bb7b5feafb9db6b8db343a66dL203-R203)